### PR TITLE
feat: home main 마크업

### DIFF
--- a/src/app/(nav)/layout.tsx
+++ b/src/app/(nav)/layout.tsx
@@ -8,8 +8,8 @@ type NavLayoutProps = {
 
 const NavLayout = ({ children }: NavLayoutProps): React.ReactElement => {
   return (
-    <div className="relative flex min-h-dvh flex-col">
-      <main className="flex-1 pb-24">{children}</main>
+    <div className="relative flex h-full flex-col">
+      <main className="flex flex-1 flex-col overflow-hidden">{children}</main>
       <div className="fixed bottom-6 left-1/2 -translate-x-1/2">
         <NavBar />
       </div>

--- a/src/app/(nav)/page.tsx
+++ b/src/app/(nav)/page.tsx
@@ -1,21 +1,24 @@
-import { BookOpen } from "lucide-react";
-
-import { Button } from "@/shared/ui/button";
+import { MOCK_DIARIES, MOCK_TODAY_DIARY } from "@/mock";
+import { DiaryListSection, HomeHeader, TodayDiaryCard, TodayEmptyState } from "@/widgets/home";
 
 const HomePage = (): React.ReactElement => {
+  const hasTodayDiary = false; // TODO: API 연동 후 실제 데이터 + 로직으로 교체
+
+  if (hasTodayDiary) {
+    return (
+      <div className="flex flex-1 flex-col overflow-y-auto bg-gray-0 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
+        <HomeHeader isWritten className="sticky top-0 z-10 bg-gray-0" />
+        <TodayDiaryCard {...MOCK_TODAY_DIARY} />
+        <DiaryListSection diaries={MOCK_DIARIES} />
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col items-center gap-8 py-10">
-      <div className="flex flex-col items-center gap-4 text-center">
-        <BookOpen className="size-12 text-primary" aria-hidden="true" />
-        <h1 className="text-4xl font-semibold tracking-tight">책 문장 일기</h1>
-        <p className="max-w-md text-base text-muted-foreground">
-          책 속 문장으로 나의 하루를 기록하는 웹 애플리케이션입니다.
-        </p>
-      </div>
-      <div className="flex gap-3">
-        <Button>오늘의 문장 작성하기</Button>
-        <Button variant="outline">문장 모아보기</Button>
-      </div>
+    <div className="flex flex-1 flex-col overflow-hidden bg-gray-0">
+      <HomeHeader />
+      <TodayEmptyState />
+      <DiaryListSection diaries={MOCK_DIARIES} className="min-h-0 flex-1 overflow-y-auto" />
     </div>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,9 +31,9 @@ type RootLayoutProps = {
 const RootLayout = ({ children }: RootLayoutProps): React.ReactElement => {
   return (
     <html lang="ko" className={`${pretendard.variable} ${nanumMyeongjo.variable}`}>
-      <body className="min-h-dvh bg-background text-foreground antialiased">
+      <body className="h-dvh overflow-hidden bg-background text-foreground antialiased">
         <Providers>
-          <div className="min-h-dvh w-full bg-gray-50 px-5 md:mx-auto md:max-w-93.75">
+          <div className="h-dvh w-full overflow-hidden bg-gray-50 md:mx-auto md:max-w-93.75">
             {children}
           </div>
         </Providers>

--- a/src/entities/diary/index.ts
+++ b/src/entities/diary/index.ts
@@ -1,0 +1,1 @@
+export type { Diary, TodayDiary } from "./model/diary.types";

--- a/src/entities/diary/model/diary.types.ts
+++ b/src/entities/diary/model/diary.types.ts
@@ -1,0 +1,15 @@
+export interface Diary {
+  day: number;
+  sentence: string;
+  temperature: number;
+  dotColor: string;
+}
+
+export interface TodayDiary {
+  temperature: number;
+  temperatureColor: string;
+  quote: string;
+  bookTitle: string;
+  bookAuthor: string;
+  note: string;
+}

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -1,0 +1,47 @@
+import type { Diary, TodayDiary } from "@/entities/diary";
+
+export const MOCK_TODAY_DIARY: TodayDiary = {
+  temperature: 72,
+  temperatureColor: "#df8b4a",
+  quote: "세상에는 두 종류의 고통이 있다. 너를 아프게 하는 고통과 너를 변하게 하는 고통",
+  bookTitle: "나미야 잡화",
+  bookAuthor: "히가시노 게이고",
+  note: "회의가 길어져서 지쳤지만, 저녁에 동네를 한 바퀴 돌았다. 벚꽃은 이미 다 졌지만 잎이 푸르게 올라온 것만으로도, 변하게 하는 고통이라는 문장이 조금 이해되었다. 이해되었다라니이...",
+};
+
+export const MOCK_DIARIES: Diary[] = [
+  { day: 24, sentence: "모든 끝은 새로운 시작이다", temperature: 78, dotColor: "#34c759" },
+  { day: 23, sentence: "우리는 서로의 거울이 된다", temperature: 74, dotColor: "#ff9500" },
+  { day: 22, sentence: "세상에는 두 종류의 고통이 있다", temperature: 72, dotColor: "#c7c7cc" },
+  { day: 21, sentence: "우리가 사랑이라 부르는 것들", temperature: 80, dotColor: "#34c759" },
+  { day: 20, sentence: "그리고 아무 말도 하지 않았다", temperature: 55, dotColor: "#ff9500" },
+  { day: 19, sentence: "바람이 불어오는 곳", temperature: 70, dotColor: "#34c759" },
+  { day: 18, sentence: "여름은 오래 그곳에 남아", temperature: 68, dotColor: "#30d158" },
+  { day: 17, sentence: "우리는 모두 별에서 왔다", temperature: 68, dotColor: "#34c759" },
+  { day: 16, sentence: "시간은 모든 것을 해결해 준다", temperature: 65, dotColor: "#ff9500" },
+  { day: 15, sentence: "행복은 작은 것들로 이루어진다", temperature: 82, dotColor: "#30d158" },
+  {
+    day: 14,
+    sentence: "사람은 결국 혼자다, 그래서 아름답다",
+    temperature: 60,
+    dotColor: "#c7c7cc",
+  },
+  { day: 13, sentence: "기억은 우리를 살게 한다", temperature: 75, dotColor: "#34c759" },
+  { day: 12, sentence: "두려움 없이 살 수는 없다", temperature: 50, dotColor: "#ff3b30" },
+  { day: 11, sentence: "말하지 못한 것들이 우리를 만든다", temperature: 63, dotColor: "#ff9500" },
+  { day: 10, sentence: "오늘도 충분히 잘 살았다", temperature: 85, dotColor: "#30d158" },
+  { day: 9, sentence: "사랑은 이해가 아니라 받아들임이다", temperature: 77, dotColor: "#34c759" },
+  { day: 8, sentence: "빛이 있는 곳에 반드시 그림자가 있다", temperature: 58, dotColor: "#c7c7cc" },
+  { day: 7, sentence: "우리는 이야기로 살아간다", temperature: 72, dotColor: "#34c759" },
+  { day: 6, sentence: "고요함 속에서 진실이 보인다", temperature: 69, dotColor: "#30d158" },
+  { day: 5, sentence: "변화는 두려움이 아닌 용기에서 온다", temperature: 76, dotColor: "#ff9500" },
+  { day: 4, sentence: "나는 내가 생각하는 것보다 강하다", temperature: 83, dotColor: "#34c759" },
+  {
+    day: 3,
+    sentence: "잃어버린 것들은 다른 형태로 돌아온다",
+    temperature: 61,
+    dotColor: "#c7c7cc",
+  },
+  { day: 2, sentence: "봄은 기억하지 못하는 사이에 온다", temperature: 74, dotColor: "#30d158" },
+  { day: 1, sentence: "모든 사람은 자신만의 속도가 있다", temperature: 70, dotColor: "#34c759" },
+];

--- a/src/widgets/home/index.ts
+++ b/src/widgets/home/index.ts
@@ -1,0 +1,4 @@
+export { DiaryListSection } from "./ui/DiaryListSection";
+export { HomeHeader } from "./ui/HomeHeader";
+export { TodayDiaryCard } from "./ui/TodayDiaryCard";
+export { TodayEmptyState } from "./ui/TodayEmptyState";

--- a/src/widgets/home/ui/DiaryListItem.tsx
+++ b/src/widgets/home/ui/DiaryListItem.tsx
@@ -1,0 +1,20 @@
+import type { Diary } from "@/entities/diary";
+
+export const DiaryListItem = ({
+  day,
+  sentence,
+  temperature,
+  dotColor,
+}: Diary): React.ReactElement => (
+  <div className="flex flex-col">
+    <div className="flex w-full items-center gap-3.75 px-6.25 py-3">
+      <span className="title3 w-[37.5px] shrink-0 translate-y-[1.5px] leading-none text-center text-gray-600">
+        {day}
+      </span>
+      <span className="size-2.25 shrink-0 rounded-full" style={{ backgroundColor: dotColor }} />
+      <span className="body3 flex-1 truncate text-left text-gray-500">{sentence}</span>
+      <span className="body3 shrink-0 text-gray-300">{temperature}°</span>
+    </div>
+    <div className="mx-6.25 border-b border-border" />
+  </div>
+);

--- a/src/widgets/home/ui/DiaryListSection.tsx
+++ b/src/widgets/home/ui/DiaryListSection.tsx
@@ -1,0 +1,41 @@
+import type { Diary } from "@/entities/diary";
+import { cn } from "@/shared/lib/utils";
+
+import { DiaryListItem } from "./DiaryListItem";
+
+interface DiaryListSectionProps {
+  diaries: Diary[];
+  className?: string;
+}
+
+export const DiaryListSection = ({
+  diaries,
+  className,
+}: DiaryListSectionProps): React.ReactElement => {
+  const month = new Date().getMonth() + 1;
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col bg-gray-50 pb-24 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]",
+        className,
+      )}
+    >
+      <div className="px-6.25 pb-3 pt-8">
+        <span className="body2 text-gray-300">{month}월 · 지난 일기</span>
+      </div>
+      {diaries.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3.5">
+          <div className="size-31.5 rounded-[4px] bg-gray-100" />
+          <p className="body1 text-gray-500">아직 작성된 일기가 없어요</p>
+        </div>
+      ) : (
+        <div className="flex flex-col">
+          {diaries.map((diary) => (
+            <DiaryListItem key={diary.day} {...diary} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/widgets/home/ui/HomeHeader.tsx
+++ b/src/widgets/home/ui/HomeHeader.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/shared/lib/utils";
+
+const DAY_NAMES = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+interface HomeHeaderProps {
+  isWritten?: boolean;
+  className?: string;
+}
+
+export const HomeHeader = ({
+  isWritten = false,
+  className,
+}: HomeHeaderProps): React.ReactElement => {
+  const today = new Date();
+  const day = today.getDate();
+  const dayName = DAY_NAMES[today.getDay()];
+
+  return (
+    <header className={cn("flex shrink-0 items-center justify-between px-5 py-3", className)}>
+      <div className="caption1 rounded-xl bg-gray-100 px-3 py-2 text-gray-400">
+        책문장 일기 로고
+      </div>
+      <span className={cn("body1", isWritten ? "text-[#34c759]" : "text-gray-300")}>
+        {day} · {dayName}요일
+      </span>
+    </header>
+  );
+};

--- a/src/widgets/home/ui/HomeHeader.tsx
+++ b/src/widgets/home/ui/HomeHeader.tsx
@@ -11,7 +11,7 @@ export const HomeHeader = ({
   isWritten = false,
   className,
 }: HomeHeaderProps): React.ReactElement => {
-  const today = new Date();
+  const today = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
   const day = today.getDate();
   const dayName = DAY_NAMES[today.getDay()];
 

--- a/src/widgets/home/ui/TodayDiaryCard.tsx
+++ b/src/widgets/home/ui/TodayDiaryCard.tsx
@@ -1,0 +1,33 @@
+import type { TodayDiary } from "@/entities/diary";
+import { cn } from "@/shared/lib/utils";
+
+interface TodayDiaryCardProps extends TodayDiary {
+  className?: string;
+}
+
+export const TodayDiaryCard = ({
+  temperature,
+  temperatureColor,
+  quote,
+  bookTitle,
+  bookAuthor,
+  note,
+  className,
+}: TodayDiaryCardProps): React.ReactElement => (
+  <section className={cn("shrink-0 px-6.25 pb-7 pt-13.75", className)}>
+    <div className="flex flex-col gap-3">
+      <p
+        className="text-2xl font-light leading-none tracking-tight"
+        style={{ color: temperatureColor }}
+      >
+        {temperature}°
+      </p>
+      <p className="title1 text-foreground">{quote}</p>
+      <p className="caption2 text-gray-400">
+        &apos;{bookTitle}&apos;, {bookAuthor}
+      </p>
+    </div>
+    <hr className="mb-3.75 mt-7 border-border" />
+    <p className="body3 line-clamp-3 text-gray-600">{note}</p>
+  </section>
+);

--- a/src/widgets/home/ui/TodayEmptyState.tsx
+++ b/src/widgets/home/ui/TodayEmptyState.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/shared/lib/utils";
+import { Button } from "@/shared/ui/button";
+
+interface TodayEmptyStateProps {
+  onWrite?: () => void;
+  className?: string;
+}
+
+export const TodayEmptyState = ({
+  onWrite,
+  className,
+}: TodayEmptyStateProps): React.ReactElement => (
+  <section className={cn("shrink-0 px-6.25 pb-7 pt-13.75", className)}>
+    <div className="flex flex-col gap-0.5">
+      <p className="title1 text-foreground">오늘,</p>
+      <p className="title1">
+        <span className="text-gray-200">당신의 </span>
+        <span className="text-foreground">문장</span>
+        <span className="text-gray-200">은</span>
+      </p>
+      <p className="title1 text-gray-200">무엇일까요?</p>
+    </div>
+    <hr className="mb-3.75 mt-7 border-border" />
+    <Button className="h-14 w-full rounded-xl subhead5" onClick={onWrite}>
+      + 오늘의 일기 작성하기
+    </Button>
+  </section>
+);


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closes #14 

## 📝 작업 요약
홈 메인 화면 UI를 구현했습니다. 오늘 일기 작성 여부에 따라 두 가지 상태(작성 전 / 작성 후)로 분기되는 레이아웃이고, FSD 구조에 맞게 위젯·엔티티 레이어를 분리했습니다.

## 🔍 주요 변경사항
- entities/diary — Diary, TodayDiary 도메인 타입 정의
- widgets/home — HomeHeader, TodayDiaryCard, TodayEmptyState, DiaryListSection, DiaryListItem 컴포넌트 구현
- mock.ts — API 연동 전 임시 목 데이터 (MOCK_DIARIES, MOCK_TODAY_DIARY) 추가
- app/layout.tsx, app/(nav)/layout.tsx — 홈 화면 스크롤 구조에 맞게 레이아웃 조정
- app/(nav)/page.tsx — 홈 페이지 구현 (오늘 일기 작성 여부 분기)
- 

## 📸 스크린샷 (선택사항)
<img width="634" height="596" alt="image" src="https://github.com/user-attachments/assets/a98e87ea-d0c5-41bc-ba8f-10841112ee52" />
<img width="267" height="466" alt="image" src="https://github.com/user-attachments/assets/39df5104-52c8-4d5a-83fe-293459b613b4" />


## 📌 PR 중요도
<!-- 해당하는 항목에 체크해주세요 -->
- [x] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [ ] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
hasTodayDiary 분기 로직 및 데이터는 API 연동 시 교체 예정입니다.
일기 작성하러 가기 버튼은 버튼 공컴 pr 머지후 교체 예정입니다