### PR TITLE
feat: 감정 선택, 입력 최종 UI

### DIFF
--- a/src/entities/sentence/index.ts
+++ b/src/entities/sentence/index.ts
@@ -1,5 +1,5 @@
 export type { RecommendedSentence } from "./model/sentence.types";
-export { SentenceTextCard } from "./ui/SentenceTextCard";
 export { SentenceCard } from "./ui/SentenceCard";
 export { SentenceListCard } from "./ui/SentenceListCard";
 export { SentenceListCardSkeleton } from "./ui/SentenceListCardSkeleton";
+export { SentenceTextCard } from "./ui/SentenceTextCard";

--- a/src/features/diary-emotion/model/emotion.ts
+++ b/src/features/diary-emotion/model/emotion.ts
@@ -1,0 +1,25 @@
+export type EmotionCategory = "bad" | "neutral" | "good";
+
+export type Emotion = {
+  id: string;
+  label: string;
+  category: EmotionCategory;
+};
+
+export const CATEGORY_BG: Record<EmotionCategory, string> = {
+  bad: "bg-key-secondary2",
+  neutral: "bg-key-primary",
+  good: "bg-key-secondary",
+};
+
+export const EMOTIONS: Emotion[] = [
+  { id: "very-good", label: "아주 기분 좋아요", category: "good" },
+  { id: "good", label: "기분 좋아요", category: "good" },
+  { id: "slightly-good", label: "약간 기분 좋아요", category: "good" },
+  { id: "quite-good", label: "꽤 괜찮아요", category: "neutral" },
+  { id: "not-bad", label: "나쁘지 않아요", category: "neutral" },
+  { id: "neutral", label: "그저그래요", category: "neutral" },
+  { id: "slightly-bad", label: "약간 별로에요", category: "bad" },
+  { id: "bad", label: "별로에요", category: "bad" },
+  { id: "very-bad", label: "아주 별로에요", category: "bad" },
+];

--- a/src/features/diary-emotion/model/useDiaryEmotionStore.ts
+++ b/src/features/diary-emotion/model/useDiaryEmotionStore.ts
@@ -4,19 +4,22 @@ import { create } from "zustand";
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
 
 type DiaryEmotionFormState = {
+  selectedEmotionId: string | null;
   selectedSituationIds: string[];
   situationDescription: string;
-  selectedSentenceTypeId: string | null;
+  selectedSentenceTypeIds: string[];
+  setSelectedEmotionId: (id: string | null) => void;
   setSelectedSituationIds: (ids: string[]) => void;
   setSituationDescription: (text: string) => void;
-  setSelectedSentenceTypeId: (id: string | null) => void;
+  setSelectedSentenceTypeIds: (ids: string[]) => void;
   reset: () => void;
 };
 
 const INITIAL_STATE = {
+  selectedEmotionId: null,
   selectedSituationIds: [] as string[],
   situationDescription: "",
-  selectedSentenceTypeId: null,
+  selectedSentenceTypeIds: [] as string[],
 };
 
 export const useDiaryEmotionStore = create<DiaryEmotionFormState>()(
@@ -24,14 +27,17 @@ export const useDiaryEmotionStore = create<DiaryEmotionFormState>()(
     persist(
       (set) => ({
         ...INITIAL_STATE,
+        setSelectedEmotionId: (id: string | null): void => {
+          set({ selectedEmotionId: id }, false, "setSelectedEmotionId");
+        },
         setSelectedSituationIds: (ids: string[]): void => {
           set({ selectedSituationIds: ids }, false, "setSelectedSituationIds");
         },
         setSituationDescription: (text: string): void => {
           set({ situationDescription: text }, false, "setSituationDescription");
         },
-        setSelectedSentenceTypeId: (id: string | null): void => {
-          set({ selectedSentenceTypeId: id }, false, "setSelectedSentenceTypeId");
+        setSelectedSentenceTypeIds: (ids: string[]): void => {
+          set({ selectedSentenceTypeIds: ids }, false, "setSelectedSentenceTypeIds");
         },
         reset: (): void => {
           set(INITIAL_STATE, false, "reset");

--- a/src/features/diary-emotion/model/useEmotionBookDrag.ts
+++ b/src/features/diary-emotion/model/useEmotionBookDrag.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { EMOTIONS, type EmotionCategory } from "./emotion";
+import { useDiaryEmotionStore } from "./useDiaryEmotionStore";
+
+const ITEM_HEIGHT = 46;
+const ITEM_GAP = 4;
+const ITEM_UNIT: number = ITEM_HEIGHT + ITEM_GAP;
+
+interface UseEmotionBookDragProps {
+  onValidChange: (isDisabled: boolean) => void;
+}
+
+export interface UseEmotionBookDragReturn {
+  selectedIndex: number | null;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  handlePointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handlePointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handlePointerUp: (e: React.PointerEvent<HTMLDivElement>) => void;
+}
+
+const getRestoredIndex = (emotionId: string | null): number | null => {
+  if (!emotionId) return null;
+  const index = EMOTIONS.findIndex((e) => e.id === emotionId);
+  return index === -1 ? null : index;
+};
+
+export const useEmotionBookDrag = ({
+  onValidChange,
+}: UseEmotionBookDragProps): UseEmotionBookDragReturn => {
+  const { selectedEmotionId, setSelectedEmotionId } = useDiaryEmotionStore();
+
+  const initialIndexRef = useRef(getRestoredIndex(selectedEmotionId));
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(initialIndexRef.current);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const prevCategoryRef = useRef<EmotionCategory | null>(
+    selectedEmotionId ? (EMOTIONS.find((e) => e.id === selectedEmotionId)?.category ?? null) : null,
+  );
+  const shouldDeselectRef = useRef(false);
+
+  useEffect(() => {
+    if (initialIndexRef.current !== null) {
+      onValidChange(false);
+    }
+  }, [onValidChange]);
+
+  const getIndexFromClientY = (clientY: number): number => {
+    if (!containerRef.current) return -1;
+    const rect = containerRef.current.getBoundingClientRect();
+    const relativeY = clientY - rect.top;
+    const rawIndex = Math.floor(relativeY / ITEM_UNIT);
+    return Math.max(0, Math.min(EMOTIONS.length - 1, rawIndex));
+  };
+
+  const trySelectEmotion = (index: number): void => {
+    const emotion = EMOTIONS[index];
+    if (!emotion) return;
+
+    if (prevCategoryRef.current !== null && prevCategoryRef.current !== emotion.category) {
+      navigator.vibrate?.(10);
+    }
+    prevCategoryRef.current = emotion.category;
+
+    if (selectedIndex === null) {
+      onValidChange(false);
+    }
+    setSelectedIndex(index);
+    setSelectedEmotionId(emotion.id);
+  };
+
+  const handleIndexChange = (clientY: number): void => {
+    const index = getIndexFromClientY(clientY);
+    if (index === selectedIndex) return;
+    trySelectEmotion(index);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>): void => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const index = getIndexFromClientY(e.clientY);
+    if (index === selectedIndex) {
+      shouldDeselectRef.current = true;
+    } else {
+      shouldDeselectRef.current = false;
+      handleIndexChange(e.clientY);
+    }
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>): void => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+    if (shouldDeselectRef.current) {
+      const index = getIndexFromClientY(e.clientY);
+      if (index !== selectedIndex) {
+        shouldDeselectRef.current = false;
+        trySelectEmotion(index);
+      }
+      return;
+    }
+    handleIndexChange(e.clientY);
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>): void => {
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    if (shouldDeselectRef.current) {
+      shouldDeselectRef.current = false;
+      setSelectedIndex(null);
+      setSelectedEmotionId(null);
+      onValidChange(true);
+    }
+  };
+
+  return { selectedIndex, containerRef, handlePointerDown, handlePointerMove, handlePointerUp };
+};

--- a/src/features/diary-emotion/model/useEmotionStep.ts
+++ b/src/features/diary-emotion/model/useEmotionStep.ts
@@ -29,7 +29,11 @@ export const useEmotionStep = (): UseEmotionStepReturn => {
   useEffect((): (() => void) => (): void => reset(), [reset]);
 
   const handleBack = (): void => {
-    router.back();
+    if (currentStep > 1) {
+      router.push(`/diary/emotion?step=${currentStep - 1}`);
+    } else {
+      router.push("/");
+    }
   };
 
   const handleNext = (): void => {

--- a/src/features/diary-emotion/ui/EmotionBookStep.tsx
+++ b/src/features/diary-emotion/ui/EmotionBookStep.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Text } from "@/shared/ui/text";
+
+import { CATEGORY_BG, EMOTIONS } from "../model/emotion";
+import { useEmotionBookDrag } from "../model/useEmotionBookDrag";
+
+interface EmotionBookStepProps {
+  onValidChange: (isDisabled: boolean) => void;
+}
+
+export const EmotionBookStep = ({ onValidChange }: EmotionBookStepProps): React.ReactElement => {
+  const { selectedIndex, containerRef, handlePointerDown, handlePointerMove, handlePointerUp } =
+    useEmotionBookDrag({ onValidChange });
+
+  const getBookClasses = (index: number): string => {
+    if (selectedIndex === null) return "bg-gray-50";
+    const selected = EMOTIONS[selectedIndex];
+    if (!selected) return "bg-gray-50";
+    if (index === selectedIndex) return CATEGORY_BG[selected.category];
+    if (index > selectedIndex) return `${CATEGORY_BG[selected.category]} opacity-70`;
+    return "bg-gray-50";
+  };
+
+  const isBookColored = (index: number): boolean => {
+    if (selectedIndex === null) return false;
+    return index >= selectedIndex;
+  };
+
+  return (
+    <div className="flex h-full flex-col pb-3.25 pt-4.75">
+      <Text variant="subhead1" color="gray-700">
+        책을 위아래로 드래그해
+        <br />
+        오늘의 기분을 표현해주세요
+      </Text>
+      <div className="max-h-17.75 flex-1" />
+      <div
+        ref={containerRef}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        className="flex flex-col gap-1 touch-none select-none"
+      >
+        {EMOTIONS.map((emotion, index) => (
+          <div
+            key={emotion.id}
+            className={`relative flex h-11.5 w-54.5 shrink-0 items-center justify-center overflow-hidden rounded-[4px] transition-[background-color,opacity] duration-150 ease-out ${getBookClasses(index)} ${index % 2 === 0 ? "mx-auto" : "ml-18"}`}
+          >
+            {selectedIndex === index && (
+              <Text
+                as="span"
+                variant="subhead1"
+                color="gray-0"
+                className="animate-in fade-in duration-150"
+              >
+                {emotion.label}
+              </Text>
+            )}
+            {isBookColored(index) && (
+              <div className="absolute left-4.25 top-0 h-12.25 w-6 bg-white opacity-20 transition-opacity duration-150 ease-out" />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/features/diary-emotion/ui/EmotionBookStep.tsx
+++ b/src/features/diary-emotion/ui/EmotionBookStep.tsx
@@ -45,7 +45,7 @@ export const EmotionBookStep = ({ onValidChange }: EmotionBookStepProps): React.
         {EMOTIONS.map((emotion, index) => (
           <div
             key={emotion.id}
-            className={`relative flex h-11.5 w-54.5 shrink-0 items-center justify-center overflow-hidden rounded-[4px] transition-[background-color,opacity] duration-150 ease-out ${getBookClasses(index)} ${index % 2 === 0 ? "mx-auto" : "ml-18"}`}
+            className={`relative flex h-11.5 w-54.5 shrink-0 items-center justify-center overflow-hidden rounded-[4px] transition-[background-color,opacity] duration-150 ease-out ${getBookClasses(index)} ${index % 2 === 0 ? "mx-auto -translate-x-1.5" : "mx-auto translate-x-1.5"}`}
           >
             {selectedIndex === index && (
               <Text

--- a/src/features/diary-emotion/ui/EmotionStepView.tsx
+++ b/src/features/diary-emotion/ui/EmotionStepView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useViewportHeight } from "@/shared/hooks/useViewportHeight";
 import { Button } from "@/shared/ui/button";
@@ -8,34 +8,28 @@ import { DoubleButton } from "@/shared/ui/double-button";
 import { Header } from "@/widgets/header";
 
 import { useEmotionStep } from "../model/useEmotionStep";
+import { EmotionBookStep } from "./EmotionBookStep";
 import { LoadingView } from "./LoadingView";
 import { SentenceTypeStep } from "./SentenceTypeStep";
 import { SituationDescriptionStep } from "./SituationDescriptionStep";
 import { SituationStep } from "./SituationStep";
-import { StepProgressBar } from "./StepProgressBar";
-import { TemperatureStep } from "./TemperatureStep";
 
 export const EmotionStepView = (): React.ReactElement => {
   useViewportHeight();
   const { currentStep, totalSteps, isLoading, handleBack, handleNext, handleSkip } =
     useEmotionStep();
-  const [isNextDisabled, setIsNextDisabled] = useState(currentStep !== 1);
-
-  useEffect(() => {
-    if (currentStep === 1) setIsNextDisabled(false);
-  }, [currentStep]);
+  const [isNextDisabled, setIsNextDisabled] = useState(true);
 
   if (isLoading) return <LoadingView />;
 
   return (
     <div
-      className="fixed inset-x-0 top-0 flex flex-col gap-1 bg-muted md:left-1/2 md:right-auto md:w-93.75 md:-translate-x-1/2"
+      className="fixed inset-x-0 top-0 flex flex-col gap-1 bg-gray0 md:left-1/2 md:right-auto md:w-93.75 md:-translate-x-1/2"
       style={{ height: "var(--vh, 100dvh)" }}
     >
       <Header onBack={handleBack} />
-      <StepProgressBar currentStep={currentStep} totalSteps={totalSteps} />
       <div className="min-h-0 flex-1 overflow-y-auto px-5">
-        {currentStep === 1 && <TemperatureStep />}
+        {currentStep === 1 && <EmotionBookStep onValidChange={setIsNextDisabled} />}
         {currentStep === 2 && <SituationStep onValidChange={setIsNextDisabled} />}
         {currentStep === 3 && <SituationDescriptionStep onValidChange={setIsNextDisabled} />}
         {currentStep === 4 && <SentenceTypeStep onValidChange={setIsNextDisabled} />}

--- a/src/features/diary-emotion/ui/SentenceTypeStep.tsx
+++ b/src/features/diary-emotion/ui/SentenceTypeStep.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { MOCK_SENTENCE_TYPES } from "@/mock";
+import { Text } from "@/shared/ui/text";
 
 import { useDiaryEmotionStore } from "../model/useDiaryEmotionStore";
 import { TagList } from "./TagList";
@@ -10,24 +11,21 @@ interface SentenceTypeStepProps {
 }
 
 export const SentenceTypeStep = ({ onValidChange }: SentenceTypeStepProps): React.ReactElement => {
-  const { selectedSentenceTypeId, setSelectedSentenceTypeId } = useDiaryEmotionStore();
+  const { selectedSentenceTypeIds, setSelectedSentenceTypeIds } = useDiaryEmotionStore();
 
   useEffect(() => {
-    onValidChange(selectedSentenceTypeId === null);
-  }, [selectedSentenceTypeId, onValidChange]);
-
-  const handleSelectionChange = (ids: string[]): void => {
-    setSelectedSentenceTypeId(ids[0] ?? null);
-  };
+    onValidChange(selectedSentenceTypeIds.length === 0);
+  }, [selectedSentenceTypeIds, onValidChange]);
 
   return (
-    <div className="flex flex-col gap-4 pt-1">
-      <div className="h-14 w-full rounded-xl bg-gray-100" />
-      <p className="body1 pt-2.5 text-foreground">오늘 어떤 문장이 필요하세요?</p>
+    <div className="flex flex-col gap-6.5 pt-1">
+      <Text variant="subhead1" className="pt-3.75">
+        오늘 어떤 문장이 필요하세요?
+      </Text>
       <TagList
         items={MOCK_SENTENCE_TYPES}
-        selectedIds={selectedSentenceTypeId ? [selectedSentenceTypeId] : []}
-        onSelectionChange={handleSelectionChange}
+        selectedIds={selectedSentenceTypeIds}
+        onSelectionChange={setSelectedSentenceTypeIds}
       />
     </div>
   );

--- a/src/features/diary-emotion/ui/SituationDescriptionStep.tsx
+++ b/src/features/diary-emotion/ui/SituationDescriptionStep.tsx
@@ -26,7 +26,7 @@ export const SituationDescriptionStep = ({
   }, [situationDescription, onValidChange]);
 
   return (
-    <div className="flex flex-col pt-5.25">
+    <div className="flex flex-col pt-8.5">
       <div className="flex flex-wrap gap-x-2.5 gap-y-3.5">
         {selectedChips.map((chip) => (
           <TagChip key={chip.id} label={chip.label} isSelected />

--- a/src/features/diary-emotion/ui/SituationStep.tsx
+++ b/src/features/diary-emotion/ui/SituationStep.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { MOCK_SITUATIONS } from "@/mock";
+import { Text } from "@/shared/ui/text";
 
 import { useDiaryEmotionStore } from "../model/useDiaryEmotionStore";
 import { TagList } from "./TagList";
@@ -17,13 +18,13 @@ export const SituationStep = ({ onValidChange }: SituationStepProps): React.Reac
   }, [selectedSituationIds, onValidChange]);
 
   return (
-    <div className="flex flex-col gap-4 pt-1">
-      <div className="h-14 w-full rounded-xl bg-gray-100" />
-      <p className="body1 pt-2.5 text-foreground">지금 어떤 상황이신가요?</p>
+    <div className="flex flex-col gap-6.5 pt-1">
+      <Text variant="subhead1" className="pt-3.75">
+        지금 어떤 상황이신가요?
+      </Text>
       <TagList
         items={MOCK_SITUATIONS}
         selectedIds={selectedSituationIds}
-        multiSelect
         onSelectionChange={setSelectedSituationIds}
       />
     </div>

--- a/src/features/diary-emotion/ui/TagChip.tsx
+++ b/src/features/diary-emotion/ui/TagChip.tsx
@@ -1,3 +1,5 @@
+import { Text } from "@/shared/ui/text";
+
 interface TagChipProps {
   label: string;
   isSelected: boolean;
@@ -5,17 +7,27 @@ interface TagChipProps {
 }
 
 export const TagChip = ({ label, isSelected, onClick }: TagChipProps): React.ReactElement => {
-  const className = `body1 rounded-full px-3 py-2 ${
-    isSelected ? "bg-gray-700 text-gray-0" : "bg-background text-gray-500"
-  }`;
+  const color = isSelected ? ("gray-50" as const) : ("gray-500" as const);
+  const baseClassName = `rounded-full px-3 py-2 ${isSelected ? "bg-gray-700" : "bg-gray-50"}`;
 
   if (!onClick) {
-    return <span className={className}>{label}</span>;
+    return (
+      <Text as="span" variant="body1" color={color} className={baseClassName}>
+        {label}
+      </Text>
+    );
   }
 
   return (
-    <button type="button" onClick={onClick} className={`cursor-pointer ${className}`}>
+    <Text
+      as="button"
+      type="button"
+      onClick={onClick}
+      variant="body1"
+      color={color}
+      className={`cursor-pointer ${baseClassName}`}
+    >
       {label}
-    </button>
+    </Text>
   );
 };

--- a/src/features/diary-emotion/ui/TagList.tsx
+++ b/src/features/diary-emotion/ui/TagList.tsx
@@ -8,22 +8,18 @@ interface TagItem {
 interface TagListProps {
   items: TagItem[];
   selectedIds: string[];
-  multiSelect?: boolean;
   onSelectionChange: (ids: string[]) => void;
 }
 
 export const TagList = ({
   items,
   selectedIds,
-  multiSelect = false,
   onSelectionChange,
 }: TagListProps): React.ReactElement => {
   const handleSelect = (id: string): void => {
-    const next = multiSelect
-      ? selectedIds.includes(id)
-        ? selectedIds.filter((s) => s !== id)
-        : [...selectedIds, id]
-      : [id];
+    const next = selectedIds.includes(id)
+      ? selectedIds.filter((s) => s !== id)
+      : [...selectedIds, id];
     onSelectionChange(next);
   };
 

--- a/src/features/diary-emotion/ui/TemperatureStep.tsx
+++ b/src/features/diary-emotion/ui/TemperatureStep.tsx
@@ -1,8 +1,0 @@
-export const TemperatureStep = (): React.ReactElement => (
-  <div className="flex flex-col pt-5.75">
-    <p className="subhead2 text-foreground">오늘의 기분을 책갈피로 표현해주세요</p>
-    <div className="mt-24 flex justify-center">
-      <div className="h-76.5 w-34.25 rounded-md bg-gray-100" />
-    </div>
-  </div>
-);

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -139,4 +139,3 @@ export const MOCK_SENTENCES: RecommendedSentence[] = [
 ];
 
 export const MOCK_SENTENCE: RecommendedSentence | undefined = MOCK_SENTENCES[0];
-


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closes #31 

## 📝 작업 요약
감정 선택, 입력 최종 UI 반영했습니다!

## 🔍 주요 변경사항
- EmotionBookStep: 책을 위아래로 드래그해 감정(9단계)을 선택하는 인터랙션 구현, 카테고리 전환 시 진동 피드백 및 CSS 트랜지션 애니메이션 적용
- 나머지 step들도 최종 UI로 조금씩 수정 했습니당!

## 📸 스크린샷 (선택사항)

https://github.com/user-attachments/assets/c0948e34-46ae-4ed2-a399-24fd90f037ae



## 📌 PR 중요도
<!-- 해당하는 항목에 체크해주세요 -->
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
책 드래그해서 선택하는 부분이 이 PR 핵심이어서 EmotionBookStep, useEmotionBookDrag 위주로 봐주시면 될 거 같습니다!
나머지는 기존 코드들에서 UI 살짝씩만 업데이트한 수준이어서 빠르게 봐주셔도 됩니당!
