### PR TITLE
refactor: 캘린더 페이지를 레이아웃 및 메인 뷰로 분리

### DIFF
--- a/src/app/(nav)/calendar/layout.tsx
+++ b/src/app/(nav)/calendar/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { CalendarHeader } from "@/widgets/calendar";
+
+type CalendarLayoutProps = {
+  children: ReactNode;
+};
+
+const CalendarLayout = ({ children }: CalendarLayoutProps): React.ReactElement => {
+  return (
+    <div className="flex flex-col h-full bg-gray-0">
+      <CalendarHeader />
+      <div className="flex-1 overflow-y-auto pb-24 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default CalendarLayout;

--- a/src/app/(nav)/calendar/page.tsx
+++ b/src/app/(nav)/calendar/page.tsx
@@ -1,20 +1,7 @@
-import { Suspense } from "react";
-import { UserProfileCard } from "@/entities/user";
-import { CalendarDiarySection, CalendarHeader, CalendarWidget } from "@/widgets/calendar";
+import { CalendarView } from "@/widgets/calendar";
 
 const CalendarPage = (): React.ReactElement => {
-  return (
-    <div className="flex flex-col h-full bg-gray-0">
-      <CalendarHeader />
-      <div className="flex-1 overflow-y-auto pb-24 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-        <UserProfileCard />
-        <Suspense>
-          <CalendarWidget />
-          <CalendarDiarySection />
-        </Suspense>
-      </div>
-    </div>
-  );
+  return <CalendarView />;
 };
 
 export default CalendarPage;

--- a/src/widgets/calendar/index.ts
+++ b/src/widgets/calendar/index.ts
@@ -1,4 +1,5 @@
 export { useCalendarDiary } from "./model/useCalendarDiary";
 export { CalendarDiarySection } from "./ui/CalendarDiarySection";
 export { CalendarHeader } from "./ui/CalendarHeader";
+export { CalendarView } from "./ui/CalendarView";
 export { CalendarWidget } from "./ui/CalendarWidget";

--- a/src/widgets/calendar/ui/CalendarView.tsx
+++ b/src/widgets/calendar/ui/CalendarView.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { UserProfileCard } from "@/entities/user";
+import { CalendarDiarySection } from "./CalendarDiarySection";
+import { CalendarWidget } from "./CalendarWidget";
+
+export const CalendarView = (): React.ReactElement => {
+  return (
+    <>
+      <UserProfileCard />
+      <Suspense>
+        <CalendarWidget />
+        <CalendarDiarySection />
+      </Suspense>
+    </>
+  );
+};


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closes #65 

## 📝 작업 요약
기존 `CalendarPage`에서 직접 조합하던 컴포넌트들을 역할에 따라 `layout.tsx`와 `CalendarView`로 분리했습니다.

## 🔍 주요 변경사항
- `app/(nav)/calendar/layout.tsx`: `CalendarHeader`와 스크롤 컨테이너를 레이아웃 레벨로 분리했습니다.
- `widgets/calendar/ui/CalendarView.tsx`: `UserProfileCard`, `CalendarWidget`, `CalendarDiarySection`을 조합하는 메인 뷰 컴포넌트입니다.
- `page.tsx`를 `<CalendarView />` 단일 렌더로 단순화했습니다.

## 📸 스크린샷 (선택사항)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
<!-- 해당하는 항목에 체크해주세요 -->
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
