### PR TITLE
fix: 이전 달 월말결산 부재 시 에러 수정

### DIFF
--- a/src/entities/report/api/reportQueries.ts
+++ b/src/entities/report/api/reportQueries.ts
@@ -14,11 +14,11 @@ export const useMonthlyReportQuery = (
   year: number,
   month: number,
   enabled = true,
-  throwOnError = true,
+  shouldThrowOnError?: boolean,
 ): UseQueryResult<MonthlyReport> =>
   useQuery({
     queryKey: reportKeys.monthly(year, month),
     queryFn: () => fetchMonthlyReport(year, month),
     enabled,
-    throwOnError,
+    ...(shouldThrowOnError === undefined ? {} : { throwOnError: shouldThrowOnError }),
   });

--- a/src/entities/report/api/reportQueries.ts
+++ b/src/entities/report/api/reportQueries.ts
@@ -14,9 +14,11 @@ export const useMonthlyReportQuery = (
   year: number,
   month: number,
   enabled = true,
+  throwOnError = true,
 ): UseQueryResult<MonthlyReport> =>
   useQuery({
     queryKey: reportKeys.monthly(year, month),
     queryFn: () => fetchMonthlyReport(year, month),
     enabled,
+    throwOnError,
   });

--- a/src/widgets/calendar/ui/CalendarView.tsx
+++ b/src/widgets/calendar/ui/CalendarView.tsx
@@ -18,7 +18,7 @@ export const CalendarView = () => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const { year: lastYear, month: lastMonth } = getLastMonth();
-  const { data: lastMonthReport } = useMonthlyReportQuery(lastYear, lastMonth);
+  const { data: lastMonthReport } = useMonthlyReportQuery(lastYear, lastMonth, true, false);
 
   return (
     <>


### PR DESCRIPTION
## 📝 작업 내용
이전 달 월말결산 부재 시 500 에러로 인해 캘린더 페이지가 나타나지 않는 오류를 수정했습니다.

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
