### PR TITLE
feat: 월말결산 없을 시 배너 노출 오류 수정

### DIFF
--- a/src/entities/report/model/report.types.ts
+++ b/src/entities/report/model/report.types.ts
@@ -22,9 +22,9 @@ export interface MonthlyReport {
   year: number;
   month: number;
   sharedQuoteCount: number;
-  mostFrequentGenre: string;
-  recommendationMessage: string;
+  mostFrequentGenre: string | null;
+  recommendationMessage: string | null;
   monthlyBooks: MonthlyBookSummary[];
   emotionTags: EmotionTag[];
-  monthlyBook: MonthlyBookQuote;
+  monthlyBook: MonthlyBookQuote | null;
 }

--- a/src/widgets/calendar/ui/CalendarView.tsx
+++ b/src/widgets/calendar/ui/CalendarView.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Suspense, useState } from "react";
-import { useMonthlyReportQuery } from "@/entities/report";
+import { type MonthlyReport, useMonthlyReportQuery } from "@/entities/report";
 import { CalendarDiarySection } from "./CalendarDiarySection";
 import { CalendarWidget } from "./CalendarWidget";
 import { MonthlyReportBanner } from "./MonthlyReportBanner";
@@ -13,6 +13,13 @@ const getLastMonth = () => {
   return { year: lastMonth.getFullYear(), month: lastMonth.getMonth() + 1 };
 };
 
+const hasReportContent = (report: MonthlyReport) =>
+  report.sharedQuoteCount > 0 &&
+  report.monthlyBooks.length > 0 &&
+  report.mostFrequentGenre !== null &&
+  report.recommendationMessage !== null &&
+  report.monthlyBook !== null;
+
 export const CalendarView = () => {
   const router = useRouter();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -22,7 +29,7 @@ export const CalendarView = () => {
 
   return (
     <>
-      {lastMonthReport && (
+      {lastMonthReport && hasReportContent(lastMonthReport) && (
         <MonthlyReportBanner
           month={lastMonth}
           onClick={() => router.push(`/report/${lastYear}/${String(lastMonth).padStart(2, "0")}`)}

--- a/src/widgets/report/ui/ReportView.tsx
+++ b/src/widgets/report/ui/ReportView.tsx
@@ -27,7 +27,13 @@ export const ReportView = () => {
 
   if (!isValidReportMonth) return null;
 
-  if (isLoading || !report) {
+  if (
+    isLoading ||
+    !report ||
+    report.mostFrequentGenre === null ||
+    report.recommendationMessage === null ||
+    report.monthlyBook === null
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## 📝 작업 내용
월말결산이 없는 경우 빈 값으로 API가 반환될 때 배너를 노출하는 문제를 해결했습니다.
- `mostFrequentGenre`, `recommendationMessage`, `monthlyBook`을 null 허용 타입으로 수정
- `CalendarView`: `sharedQuoteCount`, `monthlyBooks`, `mostFrequentGenre`, `recommendationMessage`, `monthlyBook`이 모두 존재할 때만 월말결산 배너 노출하도록 조건 추가

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
