### PR TITLE
feat: 탈퇴 구현 및 오늘의 문장 태그 칩 레이아웃 수정

### DIFF
--- a/src/entities/sentence/api/queries.ts
+++ b/src/entities/sentence/api/queries.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
 import {
   fetchRecommendationQuotes,
@@ -31,8 +31,11 @@ export const useRecommendationQuotesQuery = (recommendationId: number) =>
   });
 
 // 최종 문장 선택 뮤테이션
-export const useSelectQuoteMutation = () =>
-  useMutation({
+export const useSelectQuoteMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
     mutationFn: ({ recommendationId, quoteId }: { recommendationId: number; quoteId: number }) =>
       selectRecommendationQuote(recommendationId, quoteId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: sentenceKeys.todayStatus() }),
   });
+};

--- a/src/entities/user/api/queries.ts
+++ b/src/entities/user/api/queries.ts
@@ -3,7 +3,7 @@
 import { type UseQueryResult, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { UpdateProfileRequest, UserProfile } from "../model/user.types";
-import { fetchUserProfile, updateUserProfile } from "./userApi";
+import { deleteUserAccount, fetchUserProfile, updateUserProfile } from "./userApi";
 
 export const userKeys = {
   all: ["user"] as const,
@@ -24,3 +24,5 @@ export const useUpdateProfileMutation = () => {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: userKeys.me() }),
   });
 };
+
+export const useDeleteAccountMutation = () => useMutation({ mutationFn: deleteUserAccount });

--- a/src/entities/user/api/userApi.ts
+++ b/src/entities/user/api/userApi.ts
@@ -7,3 +7,5 @@ export const fetchUserProfile = (): Promise<UserProfile> =>
 
 export const updateUserProfile = (body: UpdateProfileRequest): Promise<UserProfile> =>
   httpClient.patch<UserProfile>("/users/me", body);
+
+export const deleteUserAccount = (): Promise<void> => httpClient.delete("/users/me");

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,2 +1,6 @@
-export { useUpdateProfileMutation, useUserProfileQuery } from "./api/queries";
+export {
+  useDeleteAccountMutation,
+  useUpdateProfileMutation,
+  useUserProfileQuery,
+} from "./api/queries";
 export type { OAuthProvider, UpdateProfileRequest, UserProfile } from "./model/user.types";

--- a/src/features/emotion-select/model/useEmotionStep.ts
+++ b/src/features/emotion-select/model/useEmotionStep.ts
@@ -1,9 +1,10 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
-import { startRecommendation } from "@/entities/sentence";
+import { sentenceKeys, startRecommendation } from "@/entities/sentence";
 import { getEmotionValue } from "@/features/emotion-select/model/emotion";
 import { useEmotionSelectStore } from "@/store/emotion-select/useEmotionSelectStore";
 
@@ -20,6 +21,7 @@ interface UseEmotionStepReturn {
 
 export const useEmotionStep = (): UseEmotionStepReturn => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const searchParams = useSearchParams();
   const rawStep = Number(searchParams.get("step"));
   const currentStep = Number.isNaN(rawStep) || rawStep < 1 || rawStep > TOTAL_STEPS ? 1 : rawStep;
@@ -61,6 +63,7 @@ export const useEmotionStep = (): UseEmotionStepReturn => {
       });
       setCurrentRecommendationId(result.recommendationId);
       setInitialRecommendedQuote(result.quote);
+      queryClient.invalidateQueries({ queryKey: sentenceKeys.todayStatus() });
       router.push("/sentence");
     } catch {
       setIsLoading(false);

--- a/src/features/emotion-select/ui/SentenceTypeStep.tsx
+++ b/src/features/emotion-select/ui/SentenceTypeStep.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { useNeedTagsQuery } from "@/entities/emotion-tag";
-import { startRecommendation } from "@/entities/sentence";
+import { sentenceKeys, startRecommendation } from "@/entities/sentence";
 import { getEmotionValue } from "@/features/emotion-select/model/emotion";
 import { IcPen } from "@/shared/ui/icons";
 import { Text } from "@/shared/ui/text";
@@ -25,6 +26,7 @@ export const SentenceTypeStep = ({
   onLoadingChange,
 }: SentenceTypeStepProps) => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const {
     selectedEmotionId,
     selectedSituationIds,
@@ -76,6 +78,7 @@ export const SentenceTypeStep = ({
       });
       setCurrentRecommendationId(result.recommendationId);
       setInitialRecommendedQuote(result.quote);
+      queryClient.invalidateQueries({ queryKey: sentenceKeys.todayStatus() });
       router.push("/sentence");
     } catch {
       setIsSubmitting(false);

--- a/src/features/sentence-select/ui/SentenceCardPhase.tsx
+++ b/src/features/sentence-select/ui/SentenceCardPhase.tsx
@@ -62,15 +62,15 @@ export const SentenceCardPhase = ({
 
     const update = () => {
       const container = containerRef.current;
-      const tagsEl = tagsRef.current;
-      if (!container || !tagsEl) return;
+      const tagsElement = tagsRef.current;
+      if (!container || !tagsElement) return;
 
       const containerWidth = container.offsetWidth;
-      const tagsWidth = tagsEl.offsetWidth;
+      const tagsWidth = tagsElement.offsetWidth;
 
-      const willWrap = tagsWidth + ChipGap + BubbleSize > containerWidth;
-      setIsWrapped(willWrap);
-      if (willWrap) {
+      const shouldWrap = tagsWidth + ChipGap + BubbleSize > containerWidth;
+      setIsWrapped(shouldWrap);
+      if (shouldWrap) {
         setTagsLeftOffset((containerWidth - tagsWidth) / 2);
       }
     };
@@ -78,6 +78,7 @@ export const SentenceCardPhase = ({
     update();
     const observer = new ResizeObserver(update);
     if (containerRef.current) observer.observe(containerRef.current);
+    if (tagsRef.current) observer.observe(tagsRef.current);
     return () => observer.disconnect();
   }, [overflowCount]);
 

--- a/src/features/sentence-select/ui/SentenceCardPhase.tsx
+++ b/src/features/sentence-select/ui/SentenceCardPhase.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import type { ReactNode } from "react";
+import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
 
 import { TagChip } from "@/entities/emotion-tag";
 import type { TagDto } from "@/entities/sentence";
@@ -49,6 +49,38 @@ export const SentenceCardPhase = ({
   const visibleTags = emotionTags.slice(0, MAX_VISIBLE_TAGS);
   const overflowCount = Math.max(0, emotionTags.length - MAX_VISIBLE_TAGS);
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tagsRef = useRef<HTMLDivElement>(null);
+  const [isWrapped, setIsWrapped] = useState(false);
+  const [tagsLeftOffset, setTagsLeftOffset] = useState(0);
+
+  const BubbleSize = 41; // size-10.25 = 10.25 * 4px
+  const ChipGap = 8; // gap-x-2 = 8px
+
+  useLayoutEffect(() => {
+    if (!overflowCount) return;
+
+    const update = () => {
+      const container = containerRef.current;
+      const tagsEl = tagsRef.current;
+      if (!container || !tagsEl) return;
+
+      const containerWidth = container.offsetWidth;
+      const tagsWidth = tagsEl.offsetWidth;
+
+      const willWrap = tagsWidth + ChipGap + BubbleSize > containerWidth;
+      setIsWrapped(willWrap);
+      if (willWrap) {
+        setTagsLeftOffset((containerWidth - tagsWidth) / 2);
+      }
+    };
+
+    update();
+    const observer = new ResizeObserver(update);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [overflowCount]);
+
   return (
     <motion.div
       className="absolute inset-0 flex flex-col overflow-hidden"
@@ -76,59 +108,74 @@ export const SentenceCardPhase = ({
         </span>
       </motion.div>
 
-      {/* Today's Text */}
-      <motion.div
-        className="relative z-10 text-center"
-        initial={{ opacity: 0, y: 16 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ ...ENTER, delay: 0.12 }}
-      >
-        <Text as="span" variant="point-eng" color="gray-300">
-          Today<span className="font-pretendard font-semibold">&apos;</span>s Text
-        </Text>
-      </motion.div>
+      {/* Scrollable content — Month stays absolute above, button stays absolute below */}
+      <div className="min-h-0 flex-1 overflow-y-auto pb-16 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {/* Today's Text */}
+        <motion.div
+          className="relative z-10 text-center"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...ENTER, delay: 0.12 }}
+        >
+          <Text as="span" variant="point-eng" color="gray-300">
+            Today<span className="font-pretendard font-semibold">&apos;</span>s Text
+          </Text>
+        </motion.div>
 
-      {/* Sentence card — centered */}
-      <motion.div
-        className="relative z-10 mt-15.75 flex justify-center"
-        initial={{ opacity: 0, y: 60 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ ...ENTER, delay: 0.18 }}
-      >
-        <TodaysSentenceCard
-          date={date}
-          quote={quote}
-          bookTitle={bookTitle}
-          bookAuthor={bookAuthor}
-          bookCoverImage={bookCoverImage}
-          animateWords
-        />
-      </motion.div>
+        {/* Sentence card — centered */}
+        <motion.div
+          className="relative z-10 mt-15.75 flex justify-center"
+          initial={{ opacity: 0, y: 60 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...ENTER, delay: 0.18 }}
+        >
+          <TodaysSentenceCard
+            date={date}
+            quote={quote}
+            bookTitle={bookTitle}
+            bookAuthor={bookAuthor}
+            bookCoverImage={bookCoverImage}
+            animateWords
+          />
+        </motion.div>
 
-      {/* Tags */}
-      <motion.div
-        className="mt-6.5 flex justify-center"
-        initial={{ opacity: 0, y: 16 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ ...ENTER, delay: 0.26 }}
-      >
-        <div className="flex w-65 flex-wrap gap-x-2 gap-y-6">
-          {visibleTags.map((tag) => (
-            <TagChip key={tag.id} label={tag.label} variant="dim" />
-          ))}
-          {overflowCount > 0 && (
-            <div className="flex size-10.25 items-center justify-center rounded-full bg-[#898989]">
-              <IcPlusCount width={13.3} height={16.62} className="text-gray-0" />
-              <span className="point2 relative -top-[1.5px] text-gray-0">{overflowCount}</span>
+        {/* Tags */}
+        <motion.div
+          className="mt-6.5 flex justify-center px-5"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...ENTER, delay: 0.26 }}
+        >
+          <div ref={containerRef} className="w-full">
+            <div className="flex justify-center gap-x-2">
+              <div ref={tagsRef} className="flex flex-nowrap gap-x-2">
+                {visibleTags.map((tag) => (
+                  <TagChip key={tag.id} label={tag.label} variant="dim" />
+                ))}
+              </div>
+              {overflowCount > 0 && !isWrapped && (
+                <div className="flex size-10.25 items-center justify-center rounded-full bg-[#898989]">
+                  <IcPlusCount width={13.3} height={16.62} className="text-gray-0" />
+                  <span className="point2 relative -top-[1.5px] text-gray-0">{overflowCount}</span>
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      </motion.div>
+            {overflowCount > 0 && isWrapped && (
+              <div
+                className="mt-2 flex size-10.25 items-center justify-center rounded-full bg-[#898989]"
+                style={{ marginLeft: tagsLeftOffset }}
+              >
+                <IcPlusCount width={13.3} height={16.62} className="text-gray-0" />
+                <span className="point2 relative -top-[1.5px] text-gray-0">{overflowCount}</span>
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </div>
 
-      <div className="flex-1" />
-
-      {/* Button bar */}
+      {/* Button bar — absolute bottom so it's always visible regardless of screen height */}
       <motion.div
+        className="absolute bottom-0 left-0 right-0 z-10"
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ ...ENTER, delay: 0.32 }}

--- a/src/shared/ui/confirm-modal.tsx
+++ b/src/shared/ui/confirm-modal.tsx
@@ -8,7 +8,7 @@ interface ConfirmModalProps {
   description: React.ReactNode;
   confirmLabel: string;
   onConfirm?: () => void;
-  singleButton?: boolean;
+  isSingleButton?: boolean;
   cancelLabel?: string;
 }
 
@@ -18,7 +18,7 @@ export const ConfirmModal = ({
   description,
   confirmLabel,
   onConfirm,
-  singleButton = false,
+  isSingleButton = false,
   cancelLabel = "취소",
 }: ConfirmModalProps) => {
   const handleConfirm = () => {
@@ -37,7 +37,7 @@ export const ConfirmModal = ({
         <div className="body1 flex items-center justify-center text-center text-gray-600">
           {description}
         </div>
-        {singleButton ? (
+        {isSingleButton ? (
           <button
             type="button"
             onClick={handleConfirm}

--- a/src/shared/ui/confirm-modal.tsx
+++ b/src/shared/ui/confirm-modal.tsx
@@ -6,18 +6,20 @@ interface ConfirmModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   description: React.ReactNode;
-  cancelLabel?: string;
   confirmLabel: string;
   onConfirm?: () => void;
+  singleButton?: boolean;
+  cancelLabel?: string;
 }
 
 export const ConfirmModal = ({
   open,
   onOpenChange,
   description,
-  cancelLabel = "취소",
   confirmLabel,
   onConfirm,
+  singleButton = false,
+  cancelLabel = "취소",
 }: ConfirmModalProps) => {
   const handleConfirm = () => {
     onConfirm?.();
@@ -35,22 +37,32 @@ export const ConfirmModal = ({
         <div className="body1 flex items-center justify-center text-center text-gray-600">
           {description}
         </div>
-        <div className="flex gap-2.5">
-          <button
-            type="button"
-            onClick={() => onOpenChange(false)}
-            className="subhead4 flex h-11.5 flex-1 items-center justify-center rounded-lg bg-gray-100 text-gray-300"
-          >
-            {cancelLabel}
-          </button>
+        {singleButton ? (
           <button
             type="button"
             onClick={handleConfirm}
-            className="subhead4 flex h-11.5 flex-1 items-center justify-center rounded-lg bg-gray-700 text-gray-0"
+            className="subhead4 flex h-11.5 w-full items-center justify-center rounded-lg bg-gray-700 text-gray-0"
           >
             {confirmLabel}
           </button>
-        </div>
+        ) : (
+          <div className="flex gap-2.5">
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="subhead4 flex h-11.5 flex-1 items-center justify-center rounded-lg bg-gray-100 text-gray-300"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirm}
+              className="subhead4 flex h-11.5 flex-1 items-center justify-center rounded-lg bg-gray-700 text-gray-0"
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/widgets/settings/ui/SettingsView.tsx
+++ b/src/widgets/settings/ui/SettingsView.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-import { useUserProfileQuery } from "@/entities/user";
+import { useDeleteAccountMutation, useUserProfileQuery } from "@/entities/user";
 import { useLogoutMutation } from "@/features/auth";
 import { ConfirmModal } from "@/shared/ui/confirm-modal";
 import { IcProfileS } from "@/shared/ui/icons";
@@ -22,9 +22,11 @@ export const SettingsView = ({ onBack }: SettingsViewProps) => {
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
+  const [isWithdrawInfoModalOpen, setIsWithdrawInfoModalOpen] = useState(false);
   const clearAuth = useAuthStore((state) => state.clearAuth);
   const router = useRouter();
   const { mutate: logoutMutate } = useLogoutMutation();
+  const { mutate: deleteAccountMutate } = useDeleteAccountMutation();
 
   const supportEmail = "sentitodayofficial@gmail.com";
 
@@ -42,9 +44,17 @@ export const SettingsView = ({ onBack }: SettingsViewProps) => {
   };
 
   const handleWithdraw = () => {
-    // TODO: 탈퇴 API 연동
-    clearAuth();
-    router.push("/login");
+    setIsWithdrawModalOpen(false);
+    setIsWithdrawInfoModalOpen(true);
+  };
+
+  const handleWithdrawConfirm = () => {
+    deleteAccountMutate(undefined, {
+      onSuccess: () => {
+        clearAuth();
+        router.push("/login");
+      },
+    });
   };
 
   return (
@@ -163,6 +173,20 @@ export const SettingsView = ({ onBack }: SettingsViewProps) => {
         cancelLabel="취소"
         confirmLabel="탈퇴"
         onConfirm={handleWithdraw}
+      />
+      <ConfirmModal
+        singleButton
+        open={isWithdrawInfoModalOpen}
+        onOpenChange={setIsWithdrawInfoModalOpen}
+        description={
+          <>
+            30일 이내 재로그인 시 탈퇴가
+            <br />
+            취소되고 계정이 복구됩니다.
+          </>
+        }
+        confirmLabel="확인"
+        onConfirm={handleWithdrawConfirm}
       />
     </div>
   );

--- a/src/widgets/settings/ui/SettingsView.tsx
+++ b/src/widgets/settings/ui/SettingsView.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 import { useDeleteAccountMutation, useUserProfileQuery } from "@/entities/user";
 import { useLogoutMutation } from "@/features/auth";
+import { useToast } from "@/shared/hooks/useToast";
 import { ConfirmModal } from "@/shared/ui/confirm-modal";
 import { IcProfileS } from "@/shared/ui/icons";
 import { useAuthStore } from "@/store/auth/useAuthStore";
@@ -27,6 +28,7 @@ export const SettingsView = ({ onBack }: SettingsViewProps) => {
   const router = useRouter();
   const { mutate: logoutMutate } = useLogoutMutation();
   const { mutate: deleteAccountMutate } = useDeleteAccountMutation();
+  const { toast } = useToast();
 
   const supportEmail = "sentitodayofficial@gmail.com";
 
@@ -53,6 +55,9 @@ export const SettingsView = ({ onBack }: SettingsViewProps) => {
       onSuccess: () => {
         clearAuth();
         router.push("/login");
+      },
+      onError: () => {
+        toast("탈퇴 처리에 실패했습니다. 다시 시도해주세요.");
       },
     });
   };
@@ -175,7 +180,7 @@ export const SettingsView = ({ onBack }: SettingsViewProps) => {
         onConfirm={handleWithdraw}
       />
       <ConfirmModal
-        singleButton
+        isSingleButton
         open={isWithdrawInfoModalOpen}
         onOpenChange={setIsWithdrawInfoModalOpen}
         description={


### PR DESCRIPTION
## 📝 작업 내용
#### 탈퇴 API 연동 및 탈퇴 모달 2단계 플로우 구현
- 탈퇴 확인 모달 1단계 → 2단계 진행 플로우 구현
- 탈퇴 API 연동

#### 오늘의 문장 태그 칩 레이아웃 수정
- 태그 칩이 가운데 정렬되지 않던 문제 수정
- 오버플로우 버블(`+N`)이 공간이 있음에도 항상 줄바꿈되던 문제 수정
- `useLayoutEffect` + `ResizeObserver`로 너비 측정 후, 공간이 있으면 한 줄, 없으면 버블을 태그 왼쪽 끝에 정렬하여 다음 줄에 배치

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
