### PR TITLE
feat: 월말결산 공유하기 기능 구현

### DIFF
--- a/src/app/report/[year]/[month]/layout.tsx
+++ b/src/app/report/[year]/[month]/layout.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
+import { useReportShare } from "@/features/report-share";
 import { IcShare4 } from "@/shared/ui/icons";
 import { Header } from "@/widgets/header";
 
@@ -11,13 +12,28 @@ interface ReportLayoutProps {
 
 const ReportLayout = ({ children }: ReportLayoutProps) => {
   const router = useRouter();
+  const { handleShare } = useReportShare();
+
   const handleBack = () => {
     router.back();
   };
 
   return (
     <div className="flex flex-col h-full bg-gray-0">
-      <Header title="월말결산" onBack={handleBack} right={<IcShare4 className="text-gray-700" />} />
+      <Header
+        title="월말결산"
+        onBack={handleBack}
+        right={
+          <button
+            type="button"
+            onClick={handleShare}
+            className="text-gray-700"
+            aria-label="공유하기"
+          >
+            <IcShare4 />
+          </button>
+        }
+      />
       <div className="flex-1 overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
         {children}
       </div>

--- a/src/features/report-share/index.ts
+++ b/src/features/report-share/index.ts
@@ -1,0 +1,1 @@
+export { useReportShare } from "./model/useReportShare";

--- a/src/features/report-share/model/useReportShare.ts
+++ b/src/features/report-share/model/useReportShare.ts
@@ -1,0 +1,19 @@
+"use client";
+
+export const useReportShare = () => {
+  const handleShare = async () => {
+    if (!navigator.share) {
+      alert("이 브라우저에서는 공유 기능을 지원하지 않아요.");
+      return;
+    }
+
+    try {
+      await navigator.share({ title: "월말결산", url: window.location.href });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      alert("공유에 실패했어요. 다시 시도해주세요.");
+    }
+  };
+
+  return { handleShare };
+};

--- a/src/widgets/report/ui/ReportMonthSelector.tsx
+++ b/src/widgets/report/ui/ReportMonthSelector.tsx
@@ -35,7 +35,7 @@ export const ReportMonthSelector = ({ year, month }: ReportMonthSelectorProps) =
     <>
       <button
         type="button"
-        className="flex items-center gap-1.5 pt-2 pb-4 px-5"
+        className="inline-flex items-center self-start gap-1.5 mt-2 mb-4 mx-5"
         onClick={() => setIsPickerOpen(true)}
       >
         <h2 className="title2 text-gray-700">{month}월</h2>


### PR DESCRIPTION
## 📝 작업 내용
- 월말결산 페이지 헤더의 공유 아이콘 클릭 시 OS 공유 시트 노출
- 월말결산 페이지에서 월 선택 버튼이 화면 전체 너비를 차지하는 문제 수정

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
