### PR TITLE
feat: 각종 공유 진입점에 문장/캘린더 이미지 공유 드로어 연결

### DIFF
--- a/src/app/(nav)/discover/page.tsx
+++ b/src/app/(nav)/discover/page.tsx
@@ -8,11 +8,12 @@ interface PageProps {
 const DiscoverPage = async ({ searchParams }: PageProps): Promise<React.ReactElement> => {
   const { search } = await searchParams;
 
-  if (search !== undefined) {
-    return <DiscoverSearchResults initialQuery={search} />;
-  }
-
-  return <DiscoverFeed />;
+  return (
+    <div className="relative flex flex-1 flex-col overflow-hidden">
+      {search !== undefined ? <DiscoverSearchResults initialQuery={search} /> : <DiscoverFeed />}
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-35 bg-linear-to-b from-transparent to-white" />
+    </div>
+  );
 };
 
 export default DiscoverPage;

--- a/src/app/diary/[id]/layout.tsx
+++ b/src/app/diary/[id]/layout.tsx
@@ -3,16 +3,18 @@
 import { format, parse } from "date-fns";
 import { ko } from "date-fns/locale";
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { DiaryDeleteModal, DiaryOptionMenu } from "@/features/diary-actions";
+import { SentenceShareCardDrawer } from "@/features/sentence-share";
 import { IcOptionHeader } from "@/shared/ui/icons";
 import { useDiaryDetail, useDiaryDetailOptions } from "@/widgets/diary-detail";
 import { Header } from "@/widgets/header";
 
 const DiaryDetailLayout = ({ children }: { children: ReactNode }) => {
   const diary = useDiaryDetail();
+  const [isShareDrawerOpen, setIsShareDrawerOpen] = useState(false);
   const {
     handleBack,
-    handleShare,
     handleDeleteClick,
     handleConfirmDelete,
     handleCancelDelete,
@@ -33,7 +35,7 @@ const DiaryDetailLayout = ({ children }: { children: ReactNode }) => {
         right={
           <DiaryOptionMenu
             trigger={<IcOptionHeader size={24} className="text-gray-700" />}
-            onShare={handleShare}
+            onShare={() => setIsShareDrawerOpen(true)}
             onDelete={handleDeleteClick}
           />
         }
@@ -44,6 +46,19 @@ const DiaryDetailLayout = ({ children }: { children: ReactNode }) => {
         onConfirm={handleConfirmDelete}
         onClose={handleCancelDelete}
       />
+      {diary && (
+        <SentenceShareCardDrawer
+          isOpen={isShareDrawerOpen}
+          shareType="sentence-pick"
+          date={diary.recommendationDate}
+          sentencePickData={{
+            quote: diary.quote.content,
+            title: diary.quote.title,
+            author: diary.quote.author,
+          }}
+          onClose={() => setIsShareDrawerOpen(false)}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/calendar-share/ui/CalendarShareCardDrawer.tsx
+++ b/src/features/calendar-share/ui/CalendarShareCardDrawer.tsx
@@ -179,7 +179,7 @@ export const CalendarShareCardDrawer = ({
                       className="size-full object-cover rounded-2xl"
                     />
                   ) : (
-                    <div className="size-full animate-pulse bg-gray-50" />
+                    <div className="size-full animate-pulse bg-gray-50 rounded-2xl" />
                   )}
                 </div>
               );

--- a/src/features/scrap-list/ui/ScrapActionSheet.tsx
+++ b/src/features/scrap-list/ui/ScrapActionSheet.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { format } from "date-fns";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
+import { SentenceShareCardDrawer } from "@/features/sentence-share";
 import { cn } from "@/shared/lib/utils";
 import { IcBookmark, IcLink, IcShare } from "@/shared/ui/icons";
 import { Sheet, SheetContent, SheetTitle } from "@/shared/ui/sheet";
@@ -31,12 +33,23 @@ export const ScrapActionSheet = ({
   bookPurchaseLink,
 }: ScrapActionSheetProps): React.ReactElement => {
   const [isBookmarked, setIsBookmarked] = useState(true);
+  const [isShareDrawerOpen, setIsShareDrawerOpen] = useState(false);
+  // 시트 닫힘 애니메이션 완료 후 드로어를 열기 위한 플래그
+  const [pendingShare, setPendingShare] = useState(false);
   const { mutateAsync: scrapAsync } = useScrapMutation();
   const { mutateAsync: unscrapAsync } = useUnscrapMutation();
 
   useEffect(() => {
     if (open) setIsBookmarked(true);
   }, [open]);
+
+  // 시트가 완전히 닫힌 후 pendingShare가 true면 드로어 열기
+  useEffect(() => {
+    if (!open && pendingShare) {
+      setIsShareDrawerOpen(true);
+      setPendingShare(false);
+    }
+  }, [open, pendingShare]);
 
   const handleBookmarkToggle = async () => {
     if (isBookmarked) {
@@ -47,62 +60,78 @@ export const ScrapActionSheet = ({
     setIsBookmarked((prev) => !prev);
   };
 
+  const handleShare = (): void => {
+    setPendingShare(true);
+    onOpenChange(false);
+  };
+
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="bottom"
-        showCloseButton={false}
-        className="overflow-visible gap-0 rounded-t-[20px] border-0 p-0 md:max-w-93.75 md:mx-auto"
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
-        <SheetTitle className="sr-only">{bookTitle}</SheetTitle>
-        {/* 책 표지 — 버튼 하단(54px)에 맞춰 위로 돌출 */}
-        <div className="absolute -top-37 left-8 h-50.5 w-32 overflow-hidden rounded-lg">
-          {coverImageUrl ? (
-            <Image src={coverImageUrl} alt={bookTitle} fill className="object-cover" />
-          ) : (
-            <div className="size-full bg-gray-100" />
-          )}
-        </div>
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          className="overflow-visible gap-0 rounded-t-[20px] border-0 p-0 md:max-w-93.75 md:mx-auto"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <SheetTitle className="sr-only">{bookTitle}</SheetTitle>
+          {/* 책 표지 — 버튼 하단(54px)에 맞춰 위로 돌출 */}
+          <div className="absolute -top-37 left-8 h-50.5 w-32 overflow-hidden rounded-lg">
+            {coverImageUrl ? (
+              <Image src={coverImageUrl} alt={bookTitle} fill className="object-cover" />
+            ) : (
+              <div className="size-full bg-gray-100" />
+            )}
+          </div>
 
-        {/* 액션 버튼 — 오른쪽 정렬 */}
-        <div className="flex items-center justify-end gap-2 pl-47.5 pr-5 pt-5 pb-2.5">
-          <a
-            href={bookPurchaseLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-2"
-          >
-            <IcLink size={16} className="text-gray-500" />
-            <span className="caption2 text-gray-500">책 링크</span>
-          </a>
-          <button
-            type="button"
-            aria-label="공유"
-            className="flex size-8.5 items-center justify-center rounded-full bg-gray-100"
-          >
-            <IcShare size={30} className="text-gray-500" />
-          </button>
-          <button
-            type="button"
-            aria-label="북마크"
-            aria-pressed={isBookmarked}
-            className="flex size-8.5 items-center justify-center"
-            onClick={handleBookmarkToggle}
-          >
-            <IcBookmark
-              size={34}
-              className={cn(isBookmarked ? "text-gray-600" : "text-gray-200")}
-            />
-          </button>
-        </div>
+          {/* 액션 버튼 — 오른쪽 정렬 */}
+          <div className="flex items-center justify-end gap-2 pl-47.5 pr-5 pt-5 pb-2.5">
+            <a
+              href={bookPurchaseLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-2"
+            >
+              <IcLink size={16} className="text-gray-500" />
+              <span className="caption2 text-gray-500">책 링크</span>
+            </a>
+            <button
+              type="button"
+              aria-label="공유"
+              onClick={handleShare}
+              className="flex size-8.5 items-center justify-center rounded-full bg-gray-100"
+            >
+              <IcShare size={30} className="text-gray-500" />
+            </button>
+            <button
+              type="button"
+              aria-label="북마크"
+              aria-pressed={isBookmarked}
+              className="flex size-8.5 items-center justify-center"
+              onClick={handleBookmarkToggle}
+            >
+              <IcBookmark
+                size={34}
+                className={cn(isBookmarked ? "text-gray-600" : "text-gray-200")}
+              />
+            </button>
+          </div>
 
-        {/* 텍스트 */}
-        <div className="flex flex-col gap-3 px-5 pt-5 pb-12">
-          <p className="subhead4 text-gray-700">{quote}</p>
-          <p className="caption2 text-gray-600">{`『${bookTitle}』, ${author}`}</p>
-        </div>
-      </SheetContent>
-    </Sheet>
+          {/* 텍스트 */}
+          <div className="flex flex-col gap-3 px-5 pt-5 pb-12">
+            <p className="subhead4 text-gray-700">{quote}</p>
+            <p className="caption2 text-gray-600">{`『${bookTitle}』, ${author}`}</p>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <SentenceShareCardDrawer
+        isOpen={isShareDrawerOpen}
+        shareType="sentence-pick"
+        date={format(new Date(), "yyyy-MM-dd")}
+        sentencePickData={{ quote, title: bookTitle, author }}
+        onClose={() => setIsShareDrawerOpen(false)}
+      />
+    </>
   );
 };

--- a/src/features/sentence-share/ui/SentenceShareCardDrawer.tsx
+++ b/src/features/sentence-share/ui/SentenceShareCardDrawer.tsx
@@ -219,10 +219,15 @@ export const SentenceShareCardDrawer = ({
                     <img
                       src={previewUrl}
                       alt={`공유 카드 ${variant}`}
-                      className="size-full object-cover"
+                      className="size-full object-cover rounded-2xl"
                     />
                   ) : (
-                    <div className={cn("size-full bg-gray-100", isLoading && "animate-pulse")} />
+                    <div
+                      className={cn(
+                        "size-full bg-gray-100 rounded-2xl",
+                        isLoading && "animate-pulse",
+                      )}
+                    />
                   )}
                 </div>
               );

--- a/src/widgets/calendar/ui/DiaryItem.tsx
+++ b/src/widgets/calendar/ui/DiaryItem.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useState } from "react";
 import {
   DiaryTagSection,
   type RecommendationListItem,
@@ -14,6 +15,7 @@ import {
   useDiaryDeleteModal,
   useDiaryOptions,
 } from "@/features/diary-actions";
+import { SentenceShareCardDrawer } from "@/features/sentence-share";
 import { IcOptionCard } from "@/shared/ui/icons";
 
 interface DiaryItemProps {
@@ -21,8 +23,10 @@ interface DiaryItemProps {
 }
 
 export const DiaryItem = ({ diary }: DiaryItemProps) => {
+  const [isShareDrawerOpen, setIsShareDrawerOpen] = useState(false);
+
   const { setSelectedDiary } = useDiaryStore();
-  const { handleShare, handleDelete } = useDiaryOptions(diary.recommendationId);
+  const { handleDelete } = useDiaryOptions(diary.recommendationId);
   const { isDeleteModalOpen, handleDeleteClick, handleConfirmDelete, handleCancelDelete } =
     useDiaryDeleteModal({ onDelete: handleDelete });
   const { data: detail } = useDiaryDetailQuery(diary.recommendationId);
@@ -62,7 +66,7 @@ export const DiaryItem = ({ diary }: DiaryItemProps) => {
       <div className="absolute right-5 top-5">
         <DiaryOptionMenu
           trigger={<IcOptionCard size={24} className="text-gray-300" />}
-          onShare={handleShare}
+          onShare={() => setIsShareDrawerOpen(true)}
           onDelete={handleDeleteOpen}
         />
       </div>
@@ -70,6 +74,17 @@ export const DiaryItem = ({ diary }: DiaryItemProps) => {
         isOpen={isDeleteModalOpen}
         onConfirm={handleConfirmDelete}
         onClose={handleCancelDelete}
+      />
+      <SentenceShareCardDrawer
+        isOpen={isShareDrawerOpen}
+        shareType="sentence-pick"
+        date={diary.recommendationDate}
+        sentencePickData={{
+          quote: diary.quote.content,
+          title: diary.quote.title,
+          author: diary.quote.author,
+        }}
+        onClose={() => setIsShareDrawerOpen(false)}
       />
     </div>
   );

--- a/src/widgets/post-share-modal/ui/PostShareModal.tsx
+++ b/src/widgets/post-share-modal/ui/PostShareModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { format } from "date-fns";
 import { useState } from "react";
 import { type Post, PostAuthorProfile, PostShareCard } from "@/entities/post";
 import { ShareScrap } from "@/features/post-share";
+import { SentenceShareCardDrawer } from "@/features/sentence-share";
 
 interface PostShareModalProps {
   post: Post;
@@ -16,15 +18,12 @@ export const PostShareModal = ({
   isOpen,
   onClose,
   onToggleBookmark,
-}: PostShareModalProps): React.ReactElement | null => {
+}: PostShareModalProps): React.ReactElement => {
   const [isBookmarked, setIsBookmarked] = useState(post.isBookmarked);
+  const [isShareDrawerOpen, setIsShareDrawerOpen] = useState(false);
 
-  const handleShare = async () => {
-    if (typeof navigator !== "undefined" && navigator.share) {
-      await navigator.share({ text: post.content }).catch(() => {});
-    } else {
-      await navigator.clipboard.writeText(post.content).catch(() => {});
-    }
+  const handleShare = (): void => {
+    setIsShareDrawerOpen(true);
   };
 
   const handleToggleBookmark = () => {
@@ -32,44 +31,61 @@ export const PostShareModal = ({
     setIsBookmarked((prev) => !prev);
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 bg-[rgba(9,9,9,0.94)]">
-      {/* Backdrop — tap to close */}
-      <button type="button" className="absolute inset-0" onClick={onClose} aria-label="닫기" />
+    <>
+      {isOpen && (
+        <div className="fixed inset-0 z-50 bg-[rgba(9,9,9,0.94)]">
+          {/* Backdrop — tap to close */}
+          <button type="button" className="absolute inset-0" onClick={onClose} aria-label="닫기" />
 
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-5">
-        <div className="flex flex-col items-center gap-6">
-          <div className="flex flex-col gap-5">
-            <PostAuthorProfile author={post.author} createdAt={post.createdAt} variant="light" />
-            <PostShareCard post={post} />
+          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-5">
+            <div className="flex flex-col items-center gap-6">
+              <div className="flex flex-col gap-5">
+                <PostAuthorProfile
+                  author={post.author}
+                  createdAt={post.createdAt}
+                  variant="light"
+                />
+                <PostShareCard post={post} />
+              </div>
+
+              {/* Mood & tone tags */}
+              <div className="flex flex-wrap justify-center gap-x-2 gap-y-6">
+                {post.toneTag && (
+                  <span className="caption2 rounded-[30px] bg-gray-600 px-2 py-1 text-white">
+                    {post.toneTag}
+                  </span>
+                )}
+                {post.emotionTag && (
+                  <span className="caption2 rounded-[30px] bg-gray-600 px-2 py-1 text-white">
+                    {post.emotionTag}
+                  </span>
+                )}
+              </div>
+            </div>
           </div>
 
-          {/* Mood & tone tags */}
-          <div className="flex flex-wrap justify-center gap-x-2 gap-y-6">
-            {post.toneTag && (
-              <span className="caption2 rounded-[30px] bg-gray-600 px-2 py-1 text-white">
-                {post.toneTag}
-              </span>
-            )}
-            {post.emotionTag && (
-              <span className="caption2 rounded-[30px] bg-gray-600 px-2 py-1 text-white">
-                {post.emotionTag}
-              </span>
-            )}
+          {/* Action bar */}
+          <div className="absolute bottom-14 left-1/2 -translate-x-1/2">
+            <ShareScrap
+              isBookmarked={isBookmarked}
+              onShare={handleShare}
+              onToggleBookmark={handleToggleBookmark}
+            />
           </div>
         </div>
-      </div>
-
-      {/* Action bar */}
-      <div className="absolute bottom-14 left-1/2 -translate-x-1/2">
-        <ShareScrap
-          isBookmarked={isBookmarked}
-          onShare={handleShare}
-          onToggleBookmark={handleToggleBookmark}
-        />
-      </div>
-    </div>
+      )}
+      <SentenceShareCardDrawer
+        isOpen={isShareDrawerOpen}
+        shareType="sentence-pick"
+        date={format(new Date(), "yyyy-MM-dd")}
+        sentencePickData={{
+          quote: post.content,
+          title: post.book.title,
+          author: post.book.author,
+        }}
+        onClose={() => setIsShareDrawerOpen(false)}
+      />
+    </>
   );
 };

--- a/src/widgets/sentence-select/ui/SentenceTodayView.tsx
+++ b/src/widgets/sentence-select/ui/SentenceTodayView.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { format } from "date-fns";
 import { AnimatePresence, LayoutGroup } from "framer-motion";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { SentenceCardPhase, SentenceDatePhase } from "@/features/sentence-select";
-import { fetchSentenceCardImage } from "@/features/sentence-share";
+import { SentenceShareCardDrawer } from "@/features/sentence-share";
 import { IcShare3 } from "@/shared/ui/icons";
 import { useEmotionSelectStore } from "@/store/emotion-select/useEmotionSelectStore";
 import { Header } from "@/widgets/header";
@@ -21,7 +20,7 @@ export const SentenceTodayView = ({
   const router = useRouter();
   const pathname = usePathname();
   const [phase, setPhase] = useState<"date" | "card">(initialPhase);
-  const [isSharing, setIsSharing] = useState(false);
+  const [isShareDrawerOpen, setIsShareDrawerOpen] = useState(false);
   const { selectedQuote, reset } = useEmotionSelectStore();
 
   const today = new Date();
@@ -38,68 +37,40 @@ export const SentenceTodayView = ({
     router.push("/");
   };
 
-  const handleShare = async (): Promise<void> => {
-    if (isSharing) return;
-
-    if (!navigator.share) {
-      alert("이 브라우저에서는 공유 기능을 지원하지 않아요.");
-      return;
-    }
-
-    if (!selectedQuote) return;
-
-    setIsSharing(true);
-    try {
-      const blob = await fetchSentenceCardImage({
-        variant: 1,
-        createdAt: format(new Date(), "yyyy-MM-dd"),
-        quote: selectedQuote.content,
-        title: selectedQuote.title,
-        author: selectedQuote.author,
-      });
-      const file = new File([blob], "sentence-today.png", { type: "image/png" });
-
-      if (!navigator.canShare?.({ files: [file] })) {
-        alert("이 기기에서는 이미지 공유를 지원하지 않아요.");
-        return;
-      }
-
-      await navigator.share({ files: [file] });
-    } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") return;
-      alert("공유에 실패했어요. 다시 시도해주세요.");
-    } finally {
-      setIsSharing(false);
-    }
-  };
-
   return (
-    <div className="relative flex-1 overflow-hidden">
-      <LayoutGroup>
-        <AnimatePresence mode="sync">
-          {phase === "date" ? (
-            <SentenceDatePhase key="date" month={month} onReveal={handleReveal} />
-          ) : (
-            <SentenceCardPhase
-              key="card"
-              header={<Header onBack={() => router.back()} />}
-              month={month}
-              date={date}
-              quote={selectedQuote?.content ?? ""}
-              bookTitle={selectedQuote?.title ?? ""}
-              bookAuthor={selectedQuote?.author ?? ""}
-              bookCoverImage={selectedQuote?.image}
-              tags={selectedQuote?.tags ?? []}
-              leftButton={{ label: "확인", isMuted: false, onClick: handleConfirm }}
-              rightButton={{
-                label: "공유하기",
-                icon: <IcShare3 size={24} className="text-gray-0" />,
-                onClick: handleShare,
-              }}
-            />
-          )}
-        </AnimatePresence>
-      </LayoutGroup>
-    </div>
+    <>
+      <div className="relative flex-1 overflow-hidden">
+        <LayoutGroup>
+          <AnimatePresence mode="sync">
+            {phase === "date" ? (
+              <SentenceDatePhase key="date" month={month} onReveal={handleReveal} />
+            ) : (
+              <SentenceCardPhase
+                key="card"
+                header={<Header onBack={() => router.back()} />}
+                month={month}
+                date={date}
+                quote={selectedQuote?.content ?? ""}
+                bookTitle={selectedQuote?.title ?? ""}
+                bookAuthor={selectedQuote?.author ?? ""}
+                bookCoverImage={selectedQuote?.image}
+                tags={selectedQuote?.tags ?? []}
+                leftButton={{ label: "확인", isMuted: false, onClick: handleConfirm }}
+                rightButton={{
+                  label: "공유하기",
+                  icon: <IcShare3 size={24} className="text-gray-0" />,
+                  onClick: () => setIsShareDrawerOpen(true),
+                }}
+              />
+            )}
+          </AnimatePresence>
+        </LayoutGroup>
+      </div>
+      <SentenceShareCardDrawer
+        isOpen={isShareDrawerOpen}
+        shareType="today-sentence"
+        onClose={() => setIsShareDrawerOpen(false)}
+      />
+    </>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용
<!-- 이 PR에서 수행한 작업을 설명해주세요 -->


**공유 드로어 진입점 연결**

- 스크랩 액션 시트, 캘린더 일기 목록, 일기 상세, 오늘의 문장, 발견 탭 게시물 모달

**전역 드로어 전환 (리팩토링)**

- 각 컴포넌트에 인라인으로 렌더링하던 방식 → Zustand 스토어 기반 전역 싱글턴으로 전환
- `useSentenceShareCardDrawer()` 훅으로 어디서든 `openSentenceShareCardDrawer(data)` 호출
- `SentenceShareDrawerRoot`를 providers.tsx에 전역 마운트

**기타**

- 발견 페이지 하단 화이트 그라디언트 추가 (홈 페이지와 통일)
- 발견 피드 스켈레톤 레이아웃 개선

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [X] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
