### PR TITLE
fix: 과거 날짜에서 문장 추천 버튼 노출 오류 수정

### DIFF
--- a/src/widgets/calendar/ui/CalendarDiarySection.tsx
+++ b/src/widgets/calendar/ui/CalendarDiarySection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format } from "date-fns";
+import { format, isToday } from "date-fns";
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/shared/lib/utils";
@@ -122,7 +122,7 @@ export const CalendarDiarySection = ({ onClose }: CalendarDiarySectionProps) => 
       </div>
       <div className="flex items-center justify-between px-5 py-3 shrink-0">
         <p className="head1 text-gray-700">{format(selectedDate, "yyyy.MM.dd")}</p>
-        {diaries.length < 5 && (
+        {isToday(selectedDate) && diaries.length < 5 && (
           <Link href="/emotion" className="flex size-7.5 items-center justify-center">
             <IcRecord size={30} className="text-key-secondary" />
           </Link>


### PR DESCRIPTION
## 📝 작업 내용
캘린더 바텀시트에서 추천 받은 문장이 5개 미만이고 날짜가 오늘인 경우에만 버튼이 나타나도록 수정했습니다.

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
