### PR TITLE
feat: 발견 탭 검색에 디바운스 적용

### DIFF
--- a/src/entities/post/api/postQueries.ts
+++ b/src/entities/post/api/postQueries.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { fetchDiscoveryQuotes, fetchDiscoveryQuotesSearch, fetchPost, fetchPosts } from "./postApi";
 
 export const postKeys = {
@@ -63,4 +63,5 @@ export const useDiscoverySearchQuery = (
       lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
     enabled: query.length > 0,
     staleTime: 30 * 1000,
+    placeholderData: keepPreviousData,
   });

--- a/src/shared/hooks/useDebounce.ts
+++ b/src/shared/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+};

--- a/src/widgets/discover-feed/ui/DiscoverFeed.tsx
+++ b/src/widgets/discover-feed/ui/DiscoverFeed.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useCallback, useState } from "react";
 import {
   type DiscoveryQuoteDto,
@@ -94,14 +95,19 @@ export const DiscoverFeed = (): React.ReactElement => {
           ))}
 
         {!isLoading && quotes.length === 0 && (
-          <div className="flex items-center justify-center py-20">
-            <span className="caption1 text-gray-300">아직 추천된 문장이 없어요.</span>
+          <div className="flex flex-col items-center justify-center gap-3 pt-40">
+            <Image src="/images/error.png" alt="" width={151} height={56} />
+            <p className="body3 text-center text-gray-500">
+              아직 발견할 수 있는
+              <br />
+              문장이 없어요
+            </p>
           </div>
         )}
 
         {isFetchingNextPage && (
           <div className="flex items-center justify-center py-4">
-            <span className="caption1 text-gray-300">불러오는 중...</span>
+            <span className="body1 text-gray-300">불러오는 중...</span>
           </div>
         )}
       </div>

--- a/src/widgets/discover-search-results/ui/DiscoverSearchResults.tsx
+++ b/src/widgets/discover-search-results/ui/DiscoverSearchResults.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   type DiscoveryQuoteSearchDto,
   PostAuthorProfile,
@@ -11,6 +11,7 @@ import {
 import { GenreFilterDropdown, useDiscoverFilter } from "@/features/discover-filter";
 import { SearchHistoryList, useSearchHistory } from "@/features/discover-search";
 import { BookmarkButton, useScrapMutation } from "@/features/post-bookmark";
+import { useDebounce } from "@/shared/hooks/useDebounce";
 import { useInfiniteScroll } from "@/shared/hooks/useInfiniteScroll";
 import { PostShareModal } from "@/widgets/post-share-modal";
 import { DiscoverSearchResultsHeader } from "./DiscoverSearchResultsHeader";
@@ -42,13 +43,33 @@ export const DiscoverSearchResults = ({
   const router = useRouter();
   const [activeSort, setActiveSort] = useState<"latest" | "scrap">("latest");
   const [selectedQuote, setSelectedQuote] = useState<DiscoveryQuoteSearchDto | null>(null);
+  const [inputQuery, setInputQuery] = useState(initialQuery);
+
+  // URL(initialQuery)이 바뀌면(명시적 제출) 로컬 상태 동기화
+  useEffect(() => {
+    setInputQuery(initialQuery);
+  }, [initialQuery]);
+
+  const debouncedQuery = useDebounce(inputQuery, 300);
 
   const { history, addToHistory, removeFromHistory } = useSearchHistory();
   const { selectedGenre, setSelectedGenre } = useDiscoverFilter();
 
   const genre = selectedGenre === "모든 장르" ? undefined : selectedGenre;
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useDiscoverySearchQuery(initialQuery, activeSort, genre);
+    useDiscoverySearchQuery(debouncedQuery, activeSort, genre);
+
+  // 데이터가 전혀 없는 첫 로딩일 때만 500ms 지연 스피너 표시
+  // isFetching(키워드 전환 중)은 placeholderData로 이전 결과를 유지하므로 스피너 불필요
+  const [showLoading, setShowLoading] = useState(false);
+  useEffect(() => {
+    if (!isLoading) {
+      setShowLoading(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowLoading(true), 500);
+    return () => clearTimeout(timer);
+  }, [isLoading]);
 
   const { toggle } = useScrapMutation();
 
@@ -74,9 +95,13 @@ export const DiscoverSearchResults = ({
 
   return (
     <div className="flex h-full flex-col">
-      <DiscoverSearchResultsHeader initialQuery={initialQuery} onConfirm={handleConfirm} />
+      <DiscoverSearchResultsHeader
+        initialQuery={initialQuery}
+        onConfirm={handleConfirm}
+        onChange={setInputQuery}
+      />
 
-      {initialQuery ? (
+      {inputQuery ? (
         <>
           {/* Sort & Filter */}
           <div className="flex items-center justify-between px-5 py-3">
@@ -105,9 +130,9 @@ export const DiscoverSearchResults = ({
 
           {/* Post list */}
           <div ref={sentinelRef} className="min-h-0 flex-1 overflow-y-auto px-5">
-            {isLoading && (
+            {showLoading && (
               <div className="flex items-center justify-center py-20">
-                <span className="caption1 text-gray-300">불러오는 중...</span>
+                <span className="body1 text-gray-400">불러오는 중...</span>
               </div>
             )}
 
@@ -141,15 +166,15 @@ export const DiscoverSearchResults = ({
                 </PostListItem>
               ))}
 
-            {!isLoading && quotes.length === 0 && (
-              <div className="flex items-center justify-center py-20">
-                <span className="caption1 text-gray-300">검색 결과가 없어요.</span>
+            {!isLoading && !showLoading && quotes.length === 0 && (
+              <div className="flex items-center justify-center py-25">
+                <span className="body1 text-gray-400">검색 결과가 없어요.</span>
               </div>
             )}
 
             {isFetchingNextPage && (
-              <div className="flex items-center justify-center py-4">
-                <span className="caption1 text-gray-300">불러오는 중...</span>
+              <div className="flex items-center justify-center py-25">
+                <span className="body1 text-gray-400">불러오는 중...</span>
               </div>
             )}
           </div>

--- a/src/widgets/discover-search-results/ui/DiscoverSearchResultsHeader.tsx
+++ b/src/widgets/discover-search-results/ui/DiscoverSearchResultsHeader.tsx
@@ -7,11 +7,13 @@ import { IcBack, IcDelete } from "@/shared/ui/icons";
 interface DiscoverSearchResultsHeaderProps {
   initialQuery: string;
   onConfirm: (value: string) => void;
+  onChange?: (value: string) => void;
 }
 
 export const DiscoverSearchResultsHeader = ({
   initialQuery,
   onConfirm,
+  onChange,
 }: DiscoverSearchResultsHeaderProps): React.ReactElement => {
   const router = useRouter();
   const [inputValue, setInputValue] = useState(initialQuery);
@@ -28,6 +30,11 @@ export const DiscoverSearchResultsHeader = ({
     }
     if (inputValue === "") router.push("/discover?search=");
   }, [inputValue, router]);
+
+  const handleChange = (value: string) => {
+    setInputValue(value);
+    onChange?.(value);
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") onConfirm(inputValue);
@@ -46,7 +53,7 @@ export const DiscoverSearchResultsHeader = ({
         <input
           type="text"
           value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
+          onChange={(e) => handleChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="문장을 검색해보세요"
           className="subhead2 flex-1 bg-transparent text-center text-gray-700 placeholder:text-gray-400 outline-none"


### PR DESCRIPTION
## 📝 작업 내용
<!-- 이 PR에서 수행한 작업을 설명해주세요 -->

- 발견 검색에 디바운스 300ms 적용으로 실시간 검색 구현
- 키워드 변경 시 이전 결과 유지(keepPreviousData)로 목록 깜빡임 방지
- 로딩 스피너 500ms 지연 노출로 순간 깜빡임 방지
- 발견 피드 빈 목록 UI 개선 (일러스트 + 안내 텍스트)

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [X] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
