### PR TITLE
feat: 장르 목록 API 연동 및 genre 파라미터 ID 기반 변경

### DIFF
--- a/src/entities/post/api/postApi.ts
+++ b/src/entities/post/api/postApi.ts
@@ -2,6 +2,7 @@ import { httpClient } from "@/shared/api/http-client";
 import type {
   DiscoveryQuoteListResponse,
   DiscoveryQuoteSearchListResponse,
+  GenreDto,
   Post,
   PostListResponse,
 } from "../model/post.types";
@@ -11,11 +12,20 @@ export const fetchPosts = (genre?: string): Promise<PostListResponse> =>
 
 export const fetchPost = (id: string): Promise<Post> => httpClient.get<Post>(`/posts/${id}`);
 
+// ── Genres ───────────────────────────────────────────────────────────────────
+
+export const fetchGenres = async (): Promise<GenreDto[]> => {
+  // biome-ignore lint/style/useNamingConvention: API response uses snake_case
+  type RawGenre = { label: string; genre_id: number };
+  const raw = await httpClient.get<RawGenre[]>("/genres");
+  return raw.map((item) => ({ label: item.label, genreId: item.genre_id }));
+};
+
 // ── Discovery ────────────────────────────────────────────────────────────────
 
 export interface FetchDiscoveryQuotesParams {
   cursor?: string;
-  genre?: string;
+  genreId?: number;
 }
 
 export const fetchDiscoveryQuotes = (
@@ -23,7 +33,7 @@ export const fetchDiscoveryQuotes = (
 ): Promise<DiscoveryQuoteListResponse> => {
   const searchParams = new URLSearchParams();
   if (params.cursor) searchParams.set("cursor", params.cursor);
-  if (params.genre && params.genre !== "모든 장르") searchParams.set("genre", params.genre);
+  if (params.genreId !== undefined) searchParams.set("genre", String(params.genreId));
   const query = searchParams.toString();
   return httpClient.get<DiscoveryQuoteListResponse>(`/discovery/quotes${query ? `?${query}` : ""}`);
 };
@@ -32,7 +42,7 @@ export interface FetchDiscoveryQuotesSearchParams {
   query: string;
   sort?: "latest" | "scrap";
   cursor?: string;
-  genre?: string;
+  genreId?: number;
 }
 
 export const fetchDiscoveryQuotesSearch = (
@@ -42,7 +52,7 @@ export const fetchDiscoveryQuotesSearch = (
   searchParams.set("query", params.query);
   if (params.sort) searchParams.set("sort", params.sort);
   if (params.cursor) searchParams.set("cursor", params.cursor);
-  if (params.genre && params.genre !== "모든 장르") searchParams.set("genre", params.genre);
+  if (params.genreId !== undefined) searchParams.set("genre", String(params.genreId));
   return httpClient.get<DiscoveryQuoteSearchListResponse>(
     `/discovery/quotes/search?${searchParams.toString()}`,
   );

--- a/src/entities/post/api/postQueries.ts
+++ b/src/entities/post/api/postQueries.ts
@@ -1,5 +1,11 @@
 import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { fetchDiscoveryQuotes, fetchDiscoveryQuotesSearch, fetchPost, fetchPosts } from "./postApi";
+import {
+  fetchDiscoveryQuotes,
+  fetchDiscoveryQuotesSearch,
+  fetchGenres,
+  fetchPost,
+  fetchPosts,
+} from "./postApi";
 
 export const postKeys = {
   all: ["posts"] as const,
@@ -22,22 +28,35 @@ export const usePostQuery = (id: string) =>
     enabled: !!id,
   });
 
+// ── Genres ───────────────────────────────────────────────────────────────────
+
+export const genreKeys = {
+  all: ["genres"] as const,
+};
+
+export const useGenresQuery = () =>
+  useQuery({
+    queryKey: genreKeys.all,
+    queryFn: fetchGenres,
+    staleTime: Infinity,
+  });
+
 // ── Discovery ────────────────────────────────────────────────────────────────
 
 export const discoveryKeys = {
   all: ["discovery"] as const,
   feeds: () => [...discoveryKeys.all, "feed"] as const,
-  feed: (genre?: string) => [...discoveryKeys.feeds(), { genre }] as const,
+  feed: (genreId?: number) => [...discoveryKeys.feeds(), { genreId }] as const,
   searches: () => [...discoveryKeys.all, "search"] as const,
-  search: (query: string, sort: string, genre?: string) =>
-    [...discoveryKeys.searches(), { query, sort, genre }] as const,
+  search: (query: string, sort: string, genreId?: number) =>
+    [...discoveryKeys.searches(), { query, sort, genreId }] as const,
 };
 
-export const useDiscoveryFeedQuery = (genre?: string) =>
+export const useDiscoveryFeedQuery = (genreId?: number) =>
   useInfiniteQuery({
-    queryKey: discoveryKeys.feed(genre),
+    queryKey: discoveryKeys.feed(genreId),
     queryFn: ({ pageParam }) =>
-      fetchDiscoveryQuotes({ cursor: pageParam as string | undefined, genre }),
+      fetchDiscoveryQuotes({ cursor: pageParam as string | undefined, genreId }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
@@ -47,16 +66,16 @@ export const useDiscoveryFeedQuery = (genre?: string) =>
 export const useDiscoverySearchQuery = (
   query: string,
   sort: "latest" | "scrap" = "latest",
-  genre?: string,
+  genreId?: number,
 ) =>
   useInfiniteQuery({
-    queryKey: discoveryKeys.search(query, sort, genre),
+    queryKey: discoveryKeys.search(query, sort, genreId),
     queryFn: ({ pageParam }) =>
       fetchDiscoveryQuotesSearch({
         query,
         sort,
         cursor: pageParam as string | undefined,
-        genre,
+        genreId,
       }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>

--- a/src/entities/post/index.ts
+++ b/src/entities/post/index.ts
@@ -1,9 +1,11 @@
-export { fetchPost, fetchPosts } from "./api/postApi";
+export { fetchGenres, fetchPost, fetchPosts } from "./api/postApi";
 export {
   discoveryKeys,
+  genreKeys,
   postKeys,
   useDiscoveryFeedQuery,
   useDiscoverySearchQuery,
+  useGenresQuery,
   usePostQuery,
   usePostsQuery,
 } from "./api/postQueries";
@@ -15,6 +17,7 @@ export type {
   DiscoveryQuoteListResponse,
   DiscoveryQuoteSearchDto,
   DiscoveryQuoteSearchListResponse,
+  GenreDto,
   Post,
   PostAuthor,
   PostBook,

--- a/src/entities/post/model/post.types.ts
+++ b/src/entities/post/model/post.types.ts
@@ -1,3 +1,8 @@
+export interface GenreDto {
+  label: string;
+  genreId: number;
+}
+
 export interface PostAuthor {
   id: string;
   nickname: string;

--- a/src/features/discover-filter/index.ts
+++ b/src/features/discover-filter/index.ts
@@ -1,4 +1,3 @@
-export type { GenreFilter } from "./model/useDiscoverFilter";
-export { GENRE_FILTERS, useDiscoverFilter } from "./model/useDiscoverFilter";
+export { useDiscoverFilter } from "./model/useDiscoverFilter";
 export { GenreFilterChips } from "./ui/GenreFilterChips";
 export { GenreFilterDropdown } from "./ui/GenreFilterDropdown";

--- a/src/features/discover-filter/model/useDiscoverFilter.ts
+++ b/src/features/discover-filter/model/useDiscoverFilter.ts
@@ -1,21 +1,7 @@
 import { useState } from "react";
 
-export const GENRE_FILTERS = [
-  "모든 장르",
-  "일반문학",
-  "시･에세이",
-  "추리･미스터리",
-  "SF",
-  "공포･스릴러",
-  "판타지",
-  "로맨스",
-  "역사",
-  "무협",
-] as const;
-export type GenreFilter = (typeof GENRE_FILTERS)[number];
-
 export const useDiscoverFilter = () => {
-  const [selectedGenre, setSelectedGenre] = useState<GenreFilter>("모든 장르");
+  const [selectedGenreId, setSelectedGenreId] = useState<number | undefined>(undefined);
 
-  return { selectedGenre, setSelectedGenre };
+  return { selectedGenreId, setSelectedGenreId };
 };

--- a/src/features/discover-filter/ui/GenreFilterChips.stories.tsx
+++ b/src/features/discover-filter/ui/GenreFilterChips.stories.tsx
@@ -1,7 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { useState } from "react";
-import type { GenreFilter } from "../model/useDiscoverFilter";
 import { GenreFilterChips } from "./GenreFilterChips";
+
+const MOCK_GENRES = [
+  { label: "일반문학", genreId: 1 },
+  { label: "시･에세이", genreId: 2 },
+  { label: "추리･미스터리", genreId: 3 },
+  { label: "SF", genreId: 4 },
+  { label: "공포･스릴러", genreId: 5 },
+  { label: "판타지", genreId: 6 },
+  { label: "로맨스", genreId: 7 },
+  { label: "역사", genreId: 8 },
+  { label: "무협", genreId: 9 },
+];
 
 const meta: Meta<typeof GenreFilterChips> = {
   title: "features/discover-filter/GenreFilterChips",
@@ -10,7 +21,7 @@ const meta: Meta<typeof GenreFilterChips> = {
   parameters: { layout: "padded" },
   decorators: [
     (Story) => (
-      <div className="w-[375px] overflow-hidden">
+      <div className="w-93.75 overflow-hidden">
         <Story />
       </div>
     ),
@@ -22,14 +33,26 @@ type Story = StoryObj<typeof GenreFilterChips>;
 
 export const Default: Story = {
   render: () => {
-    const [selected, setSelected] = useState<GenreFilter>("모든 장르");
-    return <GenreFilterChips selected={selected} onChange={setSelected} />;
+    const [selectedGenreId, setSelectedGenreId] = useState<number | undefined>(undefined);
+    return (
+      <GenreFilterChips
+        genres={MOCK_GENRES}
+        selectedGenreId={selectedGenreId}
+        onChange={setSelectedGenreId}
+      />
+    );
   },
 };
 
 export const SelectedMid: Story = {
   render: () => {
-    const [selected, setSelected] = useState<GenreFilter>("시･에세이");
-    return <GenreFilterChips selected={selected} onChange={setSelected} />;
+    const [selectedGenreId, setSelectedGenreId] = useState<number | undefined>(2);
+    return (
+      <GenreFilterChips
+        genres={MOCK_GENRES}
+        selectedGenreId={selectedGenreId}
+        onChange={setSelectedGenreId}
+      />
+    );
   },
 };

--- a/src/features/discover-filter/ui/GenreFilterChips.tsx
+++ b/src/features/discover-filter/ui/GenreFilterChips.tsx
@@ -1,27 +1,41 @@
-import { GENRE_FILTERS, type GenreFilter } from "../model/useDiscoverFilter";
+import type { GenreDto } from "@/entities/post";
 
 interface GenreFilterChipsProps {
-  selected: GenreFilter;
-  onChange: (genre: GenreFilter) => void;
+  genres: GenreDto[];
+  selectedGenreId: number | undefined;
+  onChange: (genreId: number | undefined) => void;
 }
 
 export const GenreFilterChips = ({
-  selected,
+  genres,
+  selectedGenreId,
   onChange,
 }: GenreFilterChipsProps): React.ReactElement => (
   <div className="flex gap-1.5 overflow-x-auto py-3 px-5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-    {GENRE_FILTERS.map((genre) => (
+    <button
+      key="all"
+      type="button"
+      onClick={() => onChange(undefined)}
+      className={`caption1 shrink-0 whitespace-nowrap rounded-full px-3 py-1 ${
+        selectedGenreId === undefined
+          ? "bg-gray-700 text-white"
+          : "border border-gray-200 bg-background text-gray-500"
+      }`}
+    >
+      전체
+    </button>
+    {genres.map((genre) => (
       <button
-        key={genre}
+        key={genre.genreId}
         type="button"
-        onClick={() => onChange(genre)}
+        onClick={() => onChange(genre.genreId)}
         className={`caption1 shrink-0 whitespace-nowrap rounded-full px-3 py-1 ${
-          selected === genre
+          selectedGenreId === genre.genreId
             ? "bg-gray-700 text-white"
             : "border border-gray-200 bg-background text-gray-500"
         }`}
       >
-        {genre === "모든 장르" ? "전체" : genre}
+        {genre.label}
       </button>
     ))}
   </div>

--- a/src/features/discover-filter/ui/GenreFilterDropdown.stories.tsx
+++ b/src/features/discover-filter/ui/GenreFilterDropdown.stories.tsx
@@ -2,8 +2,19 @@
 
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { useState } from "react";
-import type { GenreFilter } from "../model/useDiscoverFilter";
 import { GenreFilterDropdown } from "./GenreFilterDropdown";
+
+const MOCK_GENRES = [
+  { label: "일반문학", genreId: 1 },
+  { label: "시･에세이", genreId: 2 },
+  { label: "추리･미스터리", genreId: 3 },
+  { label: "SF", genreId: 4 },
+  { label: "공포･스릴러", genreId: 5 },
+  { label: "판타지", genreId: 6 },
+  { label: "로맨스", genreId: 7 },
+  { label: "역사", genreId: 8 },
+  { label: "무협", genreId: 9 },
+];
 
 const meta: Meta<typeof GenreFilterDropdown> = {
   title: "features/discover-filter/GenreFilterDropdown",
@@ -17,14 +28,26 @@ type Story = StoryObj<typeof GenreFilterDropdown>;
 
 export const Default: Story = {
   render: () => {
-    const [selected, setSelected] = useState<GenreFilter>("모든 장르");
-    return <GenreFilterDropdown selectedGenre={selected} onSelect={setSelected} />;
+    const [selectedGenreId, setSelectedGenreId] = useState<number | undefined>(undefined);
+    return (
+      <GenreFilterDropdown
+        genres={MOCK_GENRES}
+        selectedGenreId={selectedGenreId}
+        onSelect={setSelectedGenreId}
+      />
+    );
   },
 };
 
 export const WithGenreSelected: Story = {
   render: () => {
-    const [selected, setSelected] = useState<GenreFilter>("일반문학");
-    return <GenreFilterDropdown selectedGenre={selected} onSelect={setSelected} />;
+    const [selectedGenreId, setSelectedGenreId] = useState<number | undefined>(1);
+    return (
+      <GenreFilterDropdown
+        genres={MOCK_GENRES}
+        selectedGenreId={selectedGenreId}
+        onSelect={setSelectedGenreId}
+      />
+    );
   },
 };

--- a/src/features/discover-filter/ui/GenreFilterDropdown.tsx
+++ b/src/features/discover-filter/ui/GenreFilterDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { GenreDto } from "@/entities/post";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,42 +9,49 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { IcCheck } from "@/shared/ui/icons";
-import type { GenreFilter } from "../model/useDiscoverFilter";
-import { GENRE_FILTERS } from "../model/useDiscoverFilter";
 
 interface GenreFilterDropdownProps {
-  selectedGenre: GenreFilter;
-  onSelect: (genre: GenreFilter) => void;
+  genres: GenreDto[];
+  selectedGenreId: number | undefined;
+  onSelect: (genreId: number | undefined) => void;
 }
 
 export const GenreFilterDropdown = ({
-  selectedGenre,
+  genres,
+  selectedGenreId,
   onSelect,
-}: GenreFilterDropdownProps): React.ReactElement => (
-  <DropdownMenu>
-    <DropdownMenuTrigger className="flex items-center gap-1 rounded-lg border border-border bg-muted px-3 py-2 outline-none min-w-[127px]">
-      <IcCheck size={16} className="shrink-0 text-gray-600" />
-      <span className="caption1 text-gray-600">{selectedGenre}</span>
-    </DropdownMenuTrigger>
-    <DropdownMenuContent align="end" sideOffset={-38} className="w-[180px] px-1 py-[10px]">
-      <DropdownMenuLabel className="caption3 px-4 py-[7px] text-gray-300">
-        책 장르별 보기
-      </DropdownMenuLabel>
-      {GENRE_FILTERS.map((genre) => {
-        const isSelected = genre === selectedGenre;
-        return (
-          <DropdownMenuItem
-            key={genre}
-            onSelect={() => onSelect(genre)}
-            className={isSelected ? "min-h-11 gap-2 px-4 py-2" : "min-h-11 py-2 pl-12 pr-4"}
-          >
-            {isSelected && <IcCheck size={24} className="shrink-0 text-gray-600" />}
-            <span className={isSelected ? "subhead3 text-gray-600" : "body1 text-gray-500"}>
-              {genre}
-            </span>
-          </DropdownMenuItem>
-        );
-      })}
-    </DropdownMenuContent>
-  </DropdownMenu>
-);
+}: GenreFilterDropdownProps): React.ReactElement => {
+  const selectedLabel =
+    selectedGenreId === undefined
+      ? "전체"
+      : (genres.find((g) => g.genreId === selectedGenreId)?.label ?? "전체");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex items-center gap-1 rounded-lg border border-border bg-muted px-3 py-2 outline-none min-w-[127px]">
+        <IcCheck size={16} className="shrink-0 text-gray-600" />
+        <span className="caption1 text-gray-600">{selectedLabel}</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={-38} className="w-[180px] px-1 py-[10px]">
+        <DropdownMenuLabel className="caption3 px-4 py-[7px] text-gray-300">
+          책 장르별 보기
+        </DropdownMenuLabel>
+        {[{ label: "전체", genreId: undefined }, ...genres].map((genre) => {
+          const isSelected = genre.genreId === selectedGenreId;
+          return (
+            <DropdownMenuItem
+              key={genre.genreId ?? "all"}
+              onSelect={() => onSelect(genre.genreId)}
+              className={isSelected ? "min-h-11 gap-2 px-4 py-2" : "min-h-11 py-2 pl-12 pr-4"}
+            >
+              {isSelected && <IcCheck size={24} className="shrink-0 text-gray-600" />}
+              <span className={isSelected ? "subhead3 text-gray-600" : "body1 text-gray-500"}>
+                {genre.label}
+              </span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/features/scrap-list/ui/ScrapSentenceSection.tsx
+++ b/src/features/scrap-list/ui/ScrapSentenceSection.tsx
@@ -21,7 +21,6 @@ export const ScrapSentenceSection = () => {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [activeItem, setActiveItem] = useState<ScrappedQuote | null>(null);
-
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 

--- a/src/widgets/discover-feed/ui/DiscoverFeed.tsx
+++ b/src/widgets/discover-feed/ui/DiscoverFeed.tsx
@@ -7,6 +7,7 @@ import {
   PostAuthorProfile,
   PostListItem,
   useDiscoveryFeedQuery,
+  useGenresQuery,
 } from "@/entities/post";
 import { GenreFilterChips, useDiscoverFilter } from "@/features/discover-filter";
 import { DiscoverSearchBar, useDiscoverSearch } from "@/features/discover-search";
@@ -33,13 +34,15 @@ const formatRelativeTime = (isoString: string): string => {
 };
 
 export const DiscoverFeed = (): React.ReactElement => {
-  const { selectedGenre, setSelectedGenre } = useDiscoverFilter();
+  const { selectedGenreId, setSelectedGenreId } = useDiscoverFilter();
   const { navigateToSearch } = useDiscoverSearch();
   const [selectedQuote, setSelectedQuote] = useState<DiscoveryQuoteDto | null>(null);
 
-  const genre = selectedGenre === "모든 장르" ? undefined : selectedGenre;
+  const { data: genresData } = useGenresQuery();
+  const genres = genresData ?? [];
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useDiscoveryFeedQuery(genre);
+    useDiscoveryFeedQuery(selectedGenreId);
 
   const { toggle } = useScrapMutation();
 
@@ -58,7 +61,11 @@ export const DiscoverFeed = (): React.ReactElement => {
         <div className="px-5 pt-15">
           <DiscoverSearchBar onSubmit={(query) => navigateToSearch(query)} />
         </div>
-        <GenreFilterChips selected={selectedGenre} onChange={setSelectedGenre} />
+        <GenreFilterChips
+          genres={genres}
+          selectedGenreId={selectedGenreId}
+          onChange={setSelectedGenreId}
+        />
       </div>
 
       <div ref={sentinelRef} className="min-h-0 flex-1 overflow-y-auto px-5">

--- a/src/widgets/discover-search-results/ui/DiscoverSearchResults.tsx
+++ b/src/widgets/discover-search-results/ui/DiscoverSearchResults.tsx
@@ -7,6 +7,7 @@ import {
   PostAuthorProfile,
   PostListItem,
   useDiscoverySearchQuery,
+  useGenresQuery,
 } from "@/entities/post";
 import { GenreFilterDropdown, useDiscoverFilter } from "@/features/discover-filter";
 import { SearchHistoryList, useSearchHistory } from "@/features/discover-search";
@@ -53,11 +54,13 @@ export const DiscoverSearchResults = ({
   const debouncedQuery = useDebounce(inputQuery, 300);
 
   const { history, addToHistory, removeFromHistory } = useSearchHistory();
-  const { selectedGenre, setSelectedGenre } = useDiscoverFilter();
+  const { selectedGenreId, setSelectedGenreId } = useDiscoverFilter();
 
-  const genre = selectedGenre === "모든 장르" ? undefined : selectedGenre;
+  const { data: genresData } = useGenresQuery();
+  const genres = genresData ?? [];
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useDiscoverySearchQuery(debouncedQuery, activeSort, genre);
+    useDiscoverySearchQuery(debouncedQuery, activeSort, selectedGenreId);
 
   // 데이터가 전혀 없는 첫 로딩일 때만 500ms 지연 스피너 표시
   // isFetching(키워드 전환 중)은 placeholderData로 이전 결과를 유지하므로 스피너 불필요
@@ -125,7 +128,11 @@ export const DiscoverSearchResults = ({
                 스크랩순
               </button>
             </div>
-            <GenreFilterDropdown selectedGenre={selectedGenre} onSelect={setSelectedGenre} />
+            <GenreFilterDropdown
+              genres={genres}
+              selectedGenreId={selectedGenreId}
+              onSelect={setSelectedGenreId}
+            />
           </div>
 
           {/* Post list */}


### PR DESCRIPTION
## 📝 작업 내용
<!-- 이 PR에서 수행한 작업을 설명해주세요 -->


### API 레이어 (entities/post)

GET /genres 호출하는 fetchGenres 추가 (응답의 genre_id → genreId camelCase 변환)
useGenresQuery 추가 (staleTime: Infinity — 장르 목록은 거의 변경 없음)
피드/검색 쿼리의 genre?: string → genreId?: number 변경

### 장르 필터 (features/discover-filter)

하드코딩 GENRE_FILTERS 배열 및 GenreFilter 타입 제거
useDiscoverFilter 상태: selectedGenre: string → selectedGenreId: number | undefined
GenreFilterChips, GenreFilterDropdown 모두 genres: GenreDto[] + selectedGenreId props 기반으로 변경
위젯 (widgets)

DiscoverFeed, DiscoverSearchResults 에서 useGenresQuery로 장르 목록 fetch 후 필터 컴포넌트에 전달


## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [X] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
