### PR TITLE
feat: 공유된 월말결산 내 뒤로가기 버튼 제거

### DIFF
--- a/src/app/report/layout.tsx
+++ b/src/app/report/layout.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
-import { useReportData } from "@/entities/report";
+import { useReportData, useReportRouteContext } from "@/entities/report";
 import { useReportShare } from "@/features/report-share";
 import { IcShare4 } from "@/shared/ui/icons";
 import { Header } from "@/widgets/header";
@@ -15,6 +15,7 @@ const ReportLayout = ({ children }: ReportLayoutProps) => {
   const router = useRouter();
   const { handleShare } = useReportShare();
   const { hasReportContent } = useReportData();
+  const { isSharedView } = useReportRouteContext();
 
   const handleBack = () => {
     router.back();
@@ -25,7 +26,7 @@ const ReportLayout = ({ children }: ReportLayoutProps) => {
       <Header
         title="월말결산"
         className="z-10"
-        onBack={handleBack}
+        onBack={isSharedView ? undefined : handleBack}
         right={
           hasReportContent && (
             <button


### PR DESCRIPTION
## 📝 작업 내용
공유된 월말결산의 경우에는 헤더의 뒤로가기 버튼이 안 보이도록 변경했습니다.

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 📌 PR 중요도
- [ ] 🔴 High: 중요한 기능 추가/버그 수정 (반드시 리뷰 필요)
- [x] 🟡 Medium: 일반적인 기능 개선
- [ ] 🟢 Low: 사소한 수정/문서 업데이트

## 💬 기타 사항
<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해주세요 -->
